### PR TITLE
Visible whitespace patch

### DIFF
--- a/colors/default.jcf
+++ b/colors/default.jcf
@@ -5,6 +5,7 @@
 -menusel 	default/default inverse
 -linum		default dim
 -curlinum	default bold
+-visiblews	8 dim
 
 =Idle
 =Bad            bold red

--- a/colors/gruvbox.jcf
+++ b/colors/gruvbox.jcf
@@ -45,6 +45,7 @@
 -curlinum		[dark_yellow]/[bg1]
 -curlin			/[bg1]
 -cursor			[bg]/[fg]
+-visiblews		[bg2]
 
 =Comment		[light_gray] italic
 =TODO			inverse bold italic
@@ -146,6 +147,7 @@
 -curlinum		[dark_yellow]/[bg1]
 -curlin			/[bg1]
 -cursor			[bg]/[fg]
+-visiblews		[bg2]
 
 =Comment		[light_gray] italic
 =TODO			inverse bold italic

--- a/colors/ir_black.jcf
+++ b/colors/ir_black.jcf
@@ -72,6 +72,7 @@
 -selection /$262D51
 -linum $3D3D3D
 -cursor $000000/$ffffff
+-visiblews $808080
 
 -term 0 $4E4E4E
 -term 1 $FF6C60

--- a/colors/molokai.jcf
+++ b/colors/molokai.jcf
@@ -12,6 +12,7 @@
 -menu 81/16
 -menusel /244
 -cursor 16/231
+-visiblews 245 #81?
 
 -term 0 234
 -term 1 196
@@ -75,6 +76,7 @@
 -menu $66D9EF/$000000
 -menusel /$808080
 -cursor $000000/$F8F8F0
+-visiblews $888a85 #66d9ef?
 
 -term 0 $1B1D1E
 -term 1 $EF5939

--- a/colors/solarized.jcf
+++ b/colors/solarized.jcf
@@ -42,6 +42,7 @@
 -curlinum	[base0]
 -message	[blue]
 -cursor		[base03]/[base0]
+-visiblews	[base02]
 
 =Comment	[base01] italic
 =Constant	[cyan]

--- a/colors/wombat.jcf
+++ b/colors/wombat.jcf
@@ -8,6 +8,7 @@
 -selection /238
 -linum 244/16
 -cursor 235/242
+#TODO:-visiblews
 
 -term 0 235
 -term 1 203
@@ -50,6 +51,7 @@
 -selection /$444444
 -linum $857b6f/$000000
 -cursor $242424/$656565
+-visiblews $808080/$343434
 
 -term 0 $242424
 -term 1 $E5786D

--- a/colors/xoria.jcf
+++ b/colors/xoria.jcf
@@ -17,6 +17,7 @@
 -linum 247/233
 -curlin /237
 -cursor 16/214
+-visiblews 77
 
 =Comment 244
 =Constant 229

--- a/colors/zenburn-hc.jcf
+++ b/colors/zenburn-hc.jcf
@@ -28,6 +28,7 @@
 -menu 251/235
 -menusel 186/237 bold
 -cursor 232/109 bold
+-visiblews 151
 
 -term 0 234
 -term 1 167
@@ -93,6 +94,7 @@
 -menu $ccccbc/$242424
 -menusel $ccdc90/$353a37 bold
 -cursor $000d18/$8faf9f bold
+-visiblews $9ece9e
 
 -term 0 $1F1F1F
 -term 1 $E37170

--- a/colors/zenburn.jcf
+++ b/colors/zenburn.jcf
@@ -26,6 +26,7 @@
 -menu 247/236
 -menusel 187/235 bold
 -cursor 232/109 bold
+-visiblews 151
 
 -term 0 237
 -term 1 167
@@ -91,6 +92,7 @@
 -menu $9f9f9f/$2c2e2e
 -menusel $d0d0a0/$242424 bold
 -cursor $000d18/$8faf9f bold
+-visiblews $9ece9e
 
 -term 0 $3F3F3F
 -term 1 $E37170

--- a/joe/b.h
+++ b/joe/b.h
@@ -88,6 +88,7 @@ struct options {
 	int	spaces;
 	int	crlf;
 	int	highlight;	/* Set to enable highlighting */
+	int	visiblews;	/* Visible whitespace */
 	const char *syntax_name;	/* Name of syntax to use */
 	struct high_syntax *syntax;	/* Syntax for highlighting (load_syntax() from syntax_name happens in setopt()) */
 	const char *map_name;	/* Name of character set */

--- a/joe/bw.c
+++ b/joe/bw.c
@@ -21,6 +21,15 @@ int marking = 0;
 int selectatr = INVERSE;
 int selectmask = ~INVERSE;
 
+/* Visible whitespace text format */
+int vwsatr = DIM;
+int vwsmask = ~(DIM | FG_MASK);
+
+/* Characters used for visible whitespace */
+static int vspace = 0;
+static int vtab = 0;
+static int vrtn = 0;
+
 static P *getto(P *p, P *cur, P *top, off_t line)
 {
 
@@ -573,6 +582,11 @@ static int lgen(SCRN *t, ptrdiff_t y, int (*screen)[COMPOSE], int *attr, ptrdiff
 					}
 				}
 				if (*bp == '\n') {
+					if (bw->o.visiblews && x < w) {
+						outatr(bw->b->o.charmap, t, screen + x, attr + x, x, y, vrtn, (((atr & vwsmask) | (vwsatr & ~vwsmask)) & cm) | ca);
+						++x;
+					}
+
 					++bp;
 					++byte;
 					++amnt;
@@ -596,6 +610,11 @@ static int lgen(SCRN *t, ptrdiff_t y, int (*screen)[COMPOSE], int *attr, ptrdiff
 			if (bc == '\t') {
 				ta = p->b->o.tab - (x - ox + scr) % p->b->o.tab;
 				tach = ' ';
+				if (ta > 0 && x < w && bw->o.visiblews) {
+					outatr(bw->b->o.charmap, t, screen + x, attr + x, x, y, vtab, (((atr & vwsmask) | (vwsatr & ~vwsmask)) & cm) | ca);
+					++x;
+					--ta;
+				}
 			      dota:
 			      	while (x < w && ta--) {
 					outatr(bw->b->o.charmap, t, screen + x, attr + x, x, y, tach, (atr & cm) | ca);
@@ -605,9 +624,16 @@ static int lgen(SCRN *t, ptrdiff_t y, int (*screen)[COMPOSE], int *attr, ptrdiff
 					goto bye;
 				if (x > w)
 					goto eosl;
-			} else if (bc == '\n')
+			} else if (bc == '\n') {
+				if (bw->o.visiblews && x < w) {
+					outatr(bw->b->o.charmap, t, screen + x, attr + x, x, y, vrtn, (((atr & vwsmask) | (vwsatr & ~vwsmask)) & cm) | ca);
+					++x;
+				}
 				goto eobl;
-			else {
+			} else if (bc == ' ' && bw->o.visiblews && x < w) {
+				outatr(bw->b->o.charmap, t, screen + x, attr + x, x, y, vspace, (((atr & vwsmask) | (vwsatr & ~vwsmask)) & cm) | ca);
+				++x;
+			} else {
 				int wid = -1;
 				int utf8_char;
 				if (p->b->o.charmap->type) { /* UTF-8 */
@@ -1302,4 +1328,49 @@ int calclincols(BW *bw)
 	}
 
 	return width + 2;
+}
+
+/* Determine characters to use for visible whitespace */
+
+void init_visiblews(void)
+{
+	int spaces[] = { 0xb7, 0x2291, '.', 0 };
+	int tabs[] = { 0x2192, 0x203a, 0xbb, 0x25ba, '>', 0 };
+	int rtns[] = { 0x21b5, 0x21b2, '$', 0 };
+	int i;
+
+	vspace = vtab = vrtn = 0;
+
+	/* If we're Unicode, just take the best */
+	if (locale_map->type) {
+		vspace = spaces[0];
+		vtab = tabs[0];
+		vrtn = rtns[0];
+		return;
+	}
+
+	/* Otherwise, we need to find bytes matching the desired code points */
+	for (i = 0; spaces[i]; i++) {
+		/* Check for unicode character in locale so we can display it */
+		if (from_uni(locale_map, spaces[i]) > 0) {
+			vspace = spaces[i];
+			break;
+		}
+	}
+
+	for (i = 0; tabs[i]; i++) {
+		/* Same */
+		if (from_uni(locale_map, tabs[i]) > 0) {
+			vtab = tabs[i];
+			break;
+		}
+	}
+
+	for (i = 0; rtns[i]; i++) {
+		/* Same */
+		if (from_uni(locale_map, rtns[i]) > 0) {
+			vrtn = rtns[i];
+			break;
+		}
+	}
 }

--- a/joe/bw.h
+++ b/joe/bw.h
@@ -38,6 +38,8 @@ extern int bg_linum;	/* Attribute value for line numbers */
 extern int bg_curlinum; /* Attribute value for the line number of the current line */
 extern int bg_curlin;	/* Attribute value for the current line */
 extern int curlinmask;	/* Mask for the current line */
+extern int vwsatr;      /* Attribute value for visible whitespace */
+extern int vwsmask;     /* Attribute mask for visible whitespace */
 
 void bwfllw(W *w);
 void bwfllwt(W *w);
@@ -68,3 +70,4 @@ extern int restore_file_pos;
 void set_file_pos_all(Screen *t);
 
 BW *vtmaster(Screen *t, B *b);
+void init_visiblews(void);

--- a/joe/colors.c
+++ b/joe/colors.c
@@ -47,6 +47,7 @@ static struct color_builtin_specs color_builtins[] = {
 	{ "prompt", &bg_prompt, NULL, 0, 0, 0, &bg_text },
 	{ "message", &bg_msg, NULL, 0, 0, 0, &bg_text },
 	{ "cursor", &bg_cursor, NULL, 0, INVERSE, ~INVERSE, NULL },
+	{ "visiblews", &vwsatr, &vwsmask, 0, DIM, ~(DIM | FG_MASK), &bg_text },
 	{ NULL, NULL, NULL, 0, 0, 0, NULL }
 };
 

--- a/joe/main.c
+++ b/joe/main.c
@@ -645,6 +645,9 @@ int main(int argc, char **real_argv, const char * const *envv)
 
 	init_colors();
 
+	/* Find characters for visible whitespace in locale */
+	init_visiblews();
+
 	if (helpon) {
 		help_on(maint);
 	}

--- a/joe/options.c
+++ b/joe/options.c
@@ -54,6 +54,7 @@ OPTIONS pdefault = {
 	0,		/* crlf */
 #endif
 	0,		/* Highlight */
+	0,		/* Visible whitespace */
 	NULL,		/* Syntax name */
 	NULL,		/* Syntax */
 	NULL,		/* Name of character set */
@@ -118,6 +119,7 @@ OPTIONS fdefault = {
 	0,		/* crlf */
 #endif
 	0,		/* Highlight */
+	0,		/* Visible whitespace */
 	NULL,		/* Syntax name */
 	NULL,		/* Syntax */
 	NULL,		/* Name of character set */
@@ -404,7 +406,8 @@ struct glopts {
 	{"usetabs",	0, &opt_usetabs, NULL, 0, 0, _("Screen update uses tabs"), 0, 0, 0 },
 	{"assume_color", 0, &assume_color, NULL, 0, 0, _("Assume terminal supports color"), 0, 0, 0 },
 	{"assume_256color", 0, &assume_256color, NULL, 0, 0, _("Assume terminal supports 256 colors"), 0, 0, 0 },
-	{"joexterm", 0, &joexterm, NULL, 0, 0, _("Assume xterm patched for JOE"), 0, 0, 0 },
+	{"joexterm",	0, &joexterm, NULL, 0, 0, _("Assume xterm patched for JOE"), 0, 0, 0 },
+	{"visiblews",	4, NULL, (char *) &fdefault.visiblews, _("Visible whitespace enabled"), _("Visible whitespace disabled"), _("Visible whitespace"), 0, 0, 0 },
 	{ NULL,		0, NULL, NULL, NULL, NULL, NULL, 0, 0, 0 }
 };
 

--- a/rc/jmacsrc.in
+++ b/rc/jmacsrc.in
@@ -363,6 +363,7 @@ mode,"indentc",rtn	% % Indent char %Zindentc%
 mode,"istep",rtn	% % Indent step %Zistep%
 menu,"indent",rtn	= Indent select
 mode,"highlight",rtn	H Highlighting %Zhighlight%
+mode,"visiblews",rtn	% % Show whitespace %Zvisiblews%
 mode,"crlf",rtn	Z CR-LF/MS-DOS %Zcrlf%
 mode,"linums",rtn	N Line numbers %Zlinums%
 mode,"hiline",rtn	U Highlight line %Zhiline%

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -410,6 +410,7 @@ mode,"indentc",rtn	% % Indent char %Zindentc%
 mode,"istep",rtn	% % Indent step %Zistep%
 menu,"indent",rtn	= Indent select
 mode,"highlight",rtn	H Highlighting %Zhighlight%
+mode,"visiblews",rtn	% % Show whitespace %Zvisiblews%
 mode,"crlf",rtn	Z CR-LF/MS-DOS %Zcrlf%
 mode,"linums",rtn	N Line numbers %Zlinums%
 mode,"hiline",rtn	U Highlight line %Zhiline%

--- a/rc/jpicorc.in
+++ b/rc/jpicorc.in
@@ -388,6 +388,7 @@ mode,"indentc",rtn	% % Indent char %Zindentc%
 mode,"istep",rtn	% % Indent step %Zistep%
 menu,"indent",rtn	= Indent select
 mode,"highlight",rtn	H Highlighting %Zhighlight%
+mode,"visiblews",rtn	% % Show whitespace %Zvisiblews%
 mode,"crlf",rtn	Z CR-LF/MS-DOS %Zcrlf%
 mode,"linums",rtn	N Line numbers %Zlinums%
 mode,"hiline",rtn	U Highlight line %Zhiline%

--- a/rc/jstarrc.in
+++ b/rc/jstarrc.in
@@ -363,6 +363,7 @@ mode,"indentc",rtn	% % Indent char %Zindentc%
 mode,"istep",rtn	% % Indent step %Zistep%
 menu,"indent",rtn	= Indent select
 mode,"highlight",rtn	H Highlighting %Zhighlight%
+mode,"visiblews",rtn	% % Show whitespace %Zvisiblews%
 mode,"crlf",rtn	Z CR-LF/MS-DOS %Zcrlf%
 mode,"linums",rtn	N Line numbers %Zlinums%
 mode,"hiline",rtn	U Highlight line %Zhiline%

--- a/rc/rjoerc.in
+++ b/rc/rjoerc.in
@@ -386,6 +386,7 @@ mode,"indentc",rtn	% % Indent char %Zindentc%
 mode,"istep",rtn	% % Indent step %Zistep%
 menu,"indent",rtn	= Indent select
 mode,"highlight",rtn	H Highlighting %Zhighlight%
+mode,"visiblews",rtn	% % Show whitespace %Zvisiblews%
 mode,"crlf",rtn	Z CR-LF/MS-DOS %Zcrlf%
 mode,"linums",rtn	N Line numbers %Zlinums%
 mode,"hiline",rtn	U Highlight line %Zhiline%


### PR DESCRIPTION
Adds visible whitespace option and color scheme spec. This displays dimmed unicode glyphs to distinguish between tabs and spaces to the user.
![visualws](https://github.com/joe-editor/joe/assets/341722/04e5d6c6-12db-4130-859c-889e417b9b0b)
