### PR TITLE
Reduce excessive updates by keepup if readahead

### DIFF
--- a/joe/tw.c
+++ b/joe/tw.c
@@ -589,7 +589,7 @@ static void disptw(W *w, int flg)
 		w->curx = TO_DIFF_OK(bw->cursor->xcol - bw->offset + newcols);
 	}
 
-	if ((staupd || keepup || bw->cursor->line != tw->prevline || bw->b->changed != tw->changed || bw->b != tw->prev_b) && (w->y || !staen) && w->h > 1) {
+	if ((staupd || (keepup && !ifhave) || bw->cursor->line != tw->prevline || bw->b->changed != tw->changed || bw->b != tw->prev_b) && (w->y || !staen) && w->h > 1) {
 		char fill;
 
 		tw->prevline = bw->cursor->line;


### PR DESCRIPTION
`-keepup` causes excessive screen updates during e.g. mouse input or bracketed paste, when the prefix keys (`%k`) are updated. The status line is typically updated at least every keypress with `-keepup` and if there is waiting input, then it will get updated again, possibly overwriting the previous output. Therefore, skip status line updates with keepup when there is readahead, unless another condition triggers the change.