### PR TITLE
SF Patch 127: Support for `~/.config`

### DIFF
--- a/joe/charmap.c
+++ b/joe/charmap.c
@@ -1379,18 +1379,14 @@ struct charmap *find_charmap(const char *name)
 		if (!map_name_cmp(m->name,name))
 			return m;
 
-	/* Check ~/.joe/charmaps */
-	p = getenv("HOME");
-	f = 0;
+	/* Check for user charmap files. */
+	joe_snprintf_1(buf, SIZEOF(buf), "/charmaps/%s", name);
+	p = get_joerc_file_path(buf);
+	f = NULL;
 	if (p) {
-		joe_snprintf_2(buf,SIZEOF(buf),"%s/.joe/charmaps/%s",p,name);
-		f = fopen(buf,"r");
-	}
-
-	/* Check JOERCcharmaps */
-	if (!f) {
-		joe_snprintf_2(buf,SIZEOF(buf),"%scharmaps/%s",JOEDATA,name);
-		f = fopen(buf,"r");
+		f = fopen(p,"r");
+		joe_free(p);
+		p = NULL;
 	}
 
 	/* Parse and install character map from file */

--- a/joe/colors.c
+++ b/joe/colors.c
@@ -315,26 +315,24 @@ SCHEME *load_scheme(const char *name)
 	}
 	
 	/* Find file */
-	p = getenv("HOME");
-	if (p) {
-		joe_snprintf_2(buf, SIZEOF(buf), "%s/.joe/colors/%s.jcf", p, name);
-		f = jfopen(buf, "r");
-	}
-	
-	if (!f) {
-		joe_snprintf_2(buf, SIZEOF(buf), "%scolors/%s.jcf", JOEDATA, name);
-		f = jfopen(buf, "r");
-	}
+	joe_snprintf_1(buf, sizeof(buf), "colors/%s.jcf", name);
+	b = get_joerc_file_path(buf);
+
+	if (b)
+	f = jfopen(b, "r");
 	if (!f) {
 		joe_snprintf_1(buf, SIZEOF(buf), "*%s.jcf", name);
 		f = jfopen(buf, "r");
 	}
+
+	joe_free(b);
 	
 	if (!f) {
 		return 0;
 	}
-	
+    
 	/* Create */
+	b = NULL;
 	colors = (SCHEME *) joe_malloc(SIZEOF(struct color_scheme));
 	colors->sets = NULL;
 	colors->name = zdup(name);

--- a/joe/colors.c
+++ b/joe/colors.c
@@ -118,7 +118,7 @@ static int parse_scoped_ident(const char **p, char *dest, ptrdiff_t sz)
 			return 0;
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -140,7 +140,7 @@ int parse_color_spec(const char **p, struct color_spec *dest)
 		if (!parse_ws(p, '#')) {
 			return 0;
 		}
-		
+
 		if (!parse_char(p, '/')) {
 			if (!fg) {
 				/* Background already selected */
@@ -151,22 +151,22 @@ int parse_color_spec(const char **p, struct color_spec *dest)
 			bg = 1;
 		} else if (!parse_char(p, '$')) {
 			int i;
-			
+
 			/* GUI color */
 			if (dest->type != COLORSPEC_TYPE_NONE && dest->type != COLORSPEC_TYPE_GUI) {
 				/* Can't mix GUI and term */
 				return 1;
 			}
-			
+
 			dest->type = COLORSPEC_TYPE_GUI;
 			i = 0;
 			while (**p && ((**p >= 'a' && **p <= 'f') || (**p >= '0' && **p <= '9') || (**p >= 'A' && **p <= 'F'))) {
 				buf[i++] = *((*p)++);
 			}
-			
+
 			buf[i] = 0;
 			color = zhtoi(buf);
-			
+
 			if (fg && !fg_read) {
 				dest->gui_fg = color;
 				dest->mask |= FG_MASK;
@@ -182,7 +182,7 @@ int parse_color_spec(const char **p, struct color_spec *dest)
 				/* Can't mix GUI and term */
 				return 1;
 			}
-			
+
 			dest->type = COLORSPEC_TYPE_ATTR;
 			if (fg && !fg_read) {
 				dest->atr |= (color << FG_SHIFT) | FG_NOT_DEFAULT;
@@ -197,14 +197,14 @@ int parse_color_spec(const char **p, struct color_spec *dest)
 			}
 		} else if (!parse_ident(p, buf, SIZEOF(buf))) {
 			int dflt = 0;
-			
+
 			if (!zcmp(buf, "default")) {
 				dflt = 1;
 				color = 0;
 			} else if (!(color = meta_color(buf))) {
 				return 1;
 			}
-			
+
 			/* If we got color data, then make sure the spec is the right type. */
 			if ((color & (FG_MASK | BG_MASK)) != 0) {
 				if (dest->type != COLORSPEC_TYPE_NONE && dest->type != COLORSPEC_TYPE_ATTR) {
@@ -212,12 +212,12 @@ int parse_color_spec(const char **p, struct color_spec *dest)
 					return 1;
 				}
 			}
-			
+
 			if (dest->type == COLORSPEC_TYPE_NONE) {
 				/* If no color has been specified yet, we'll just assume TERM */
 				dest->type = COLORSPEC_TYPE_ATTR;
 			}
-			
+
 			if (bg && !bg_read && (FG_MASK & color)) {
 				/* translate "foreground" color to background */
 				dest->atr |= BG_NOT_DEFAULT | SWAP_COLOR(FG_MASK & color);
@@ -306,14 +306,14 @@ SCHEME *load_scheme(const char *name)
 	char *b = NULL;
 	JFILE *f = NULL;
 	int line, i;
-	
+
 	/* Find existing */
 	for (colors = allcolors.link.next; colors != &allcolors; colors = colors->link.next) {
 		if (!zcmp(name, colors->name)) {
 			return colors;
 		}
 	}
-	
+
 	/* Find file */
 	joe_snprintf_1(buf, sizeof(buf), "colors/%s.jcf", name);
 	b = get_joerc_file_path(buf);
@@ -326,11 +326,11 @@ SCHEME *load_scheme(const char *name)
 	}
 
 	joe_free(b);
-	
+
 	if (!f) {
 		return 0;
 	}
-    
+
 	/* Create */
 	b = NULL;
 	colors = (SCHEME *) joe_malloc(SIZEOF(struct color_scheme));
@@ -339,22 +339,22 @@ SCHEME *load_scheme(const char *name)
 	enquef(SCHEME, link, &allcolors, colors);
 	curset = 0;
 	line = 0;
-	
+
 	while (jfgets(buf, SIZEOF(buf), f)) {
 		++line;
-		
+
 		/* Replace [macros] with their values */
 		b = preprocess_line(b, buf, macros);
-		
+
 		p = b;
 		parse_ws(&p, '#');
-		
+
 		if (!parse_char(&p, '.')) {
 			/* .colors, .set */
 			if (!parse_ident(&p, bf, SIZEOF(bf))) {
 				if (!zcmp(bf, "colors")) {
 					int count = -1;
-					
+
 					parse_ws(&p, '#');
 					if (!parse_char(&p, '*')) {
 						/* GUI */
@@ -378,15 +378,15 @@ SCHEME *load_scheme(const char *name)
 						struct color_macro *newmacro;
 						const char *q;
 						parse_ws(&p, '#');
-						
+
 						/* q = start */
 						q = p;
 						while (*p && *p != '#' && *p != '\n' && *p != '\r') {
 							p++;
 						}
-						
+
 						/* p = end */
-						
+
 						/* Add macro */
 						newmacro = joe_malloc(SIZEOF(struct color_macro));
 						newmacro->next = macros;
@@ -410,7 +410,7 @@ SCHEME *load_scheme(const char *name)
 				if (!zicmp(bf, "term")) {
 					/* -term */
 					int termcolor;
-					
+
 					parse_ws(&p, '#');
 					if (!parse_int(&p, &termcolor) && termcolor >= 0 && termcolor <= 15) {
 						if (parse_color_spec(&p, &curset->termcolors[termcolor])) {
@@ -426,11 +426,11 @@ SCHEME *load_scheme(const char *name)
 							if (parse_color_spec(&p, &curset->builtins[i])) {
 								logerror_2(joe_gettext(_("%s: %d: Invalid color spec\n")), name, line);
 							}
-							
+
 							break;
 						}
 					}
-					
+
 					if (!color_builtins[i].name) {
 						logerror_3(joe_gettext(_("%s: %d: Unknown builtin color %s\n")), name, line, bf);
 					}
@@ -442,10 +442,10 @@ SCHEME *load_scheme(const char *name)
 			/* =SyntaxColors */
 			if (!parse_scoped_ident(&p, bf, SIZEOF(bf))) {
 				struct color_def *cdef;
-				
+
 				cdef = (struct color_def *) joe_calloc(1, SIZEOF(struct color_def));
 				cdef->name = atom_add(bf);
-				
+
 				if (!parse_color_def(&p, cdef)) {
 					htadd(curset->syntax, cdef->name, cdef);
 					*lastdef = cdef;
@@ -459,10 +459,10 @@ SCHEME *load_scheme(const char *name)
 			}
 		}
 	}
-	
+
 	vsrm(b);
 	jfclose(f);
-	
+
 	/* Clean up macros */
 	while (macros) {
 		struct color_macro *next = macros->next;
@@ -471,38 +471,38 @@ SCHEME *load_scheme(const char *name)
 		joe_free(macros);
 		macros = next;
 	}
-	
+
 	/* Resolve refs in each set */
 	for (curset = colors->sets; curset; curset = curset->next) {
 		struct color_def *cdef;
-		
+
 		/* Reset */
 		for (cdef = curset->alldefs; cdef; cdef = cdef->next) {
 			cdef->visited = 0;
 		}
-		
+
 		/* Visit */
 		for (cdef = curset->alldefs; cdef; cdef = cdef->next) {
 			struct color_ref *cref = cdef->refs;
-			
+
 			visit_colordef(curset, NULL, cdef);
-			
+
 			/* Remove references */
 			while (cref) {
 				struct color_ref *prev = cref;
 				cref = cref->next;
 				joe_free(prev);
 			}
-			
+
 			cdef->refs = NULL;
-			
+
 			/* Lock in color */
 			if (cdef->spec.type == COLORSPEC_TYPE_NONE) {
 				cdef->spec.type = COLORSPEC_TYPE_ATTR;
 				cdef->spec.atr = 0;
 			}
 		}
-		
+
 		/* If this is GUI, then make the palette */
 		if (curset->colors == COLORSET_GUI) {
 			build_palette(curset, 1);
@@ -510,7 +510,7 @@ SCHEME *load_scheme(const char *name)
 			curset->palette = NULL;
 		}
 	}
-	
+
 	return colors;
 }
 
@@ -518,20 +518,20 @@ SCHEME *load_scheme(const char *name)
 static char *preprocess_line(char *p, char *bf, struct color_macro *macros)
 {
 	ptrdiff_t i;
-	
+
 	p = vstrunc(p, 0);
 	p = vsensure(p, zlen(bf));
-	
+
 	for (i = 0; bf[i] && bf[i] != '#'; i++) {
 		if (bf[i] == '[') {
 			/* Found start, find end */
 			ptrdiff_t t;
-			
+
 			for (t = i + 1; bf[t] && bf[t] != '#' && bf[t] != ']'; t++) {}
-			
+
 			if (bf[t] == ']') {
 				struct color_macro *m = macros;
-				
+
 				/* Lookup */
 				bf[t] = 0;
 				for (; m; m = m->next) {
@@ -539,9 +539,9 @@ static char *preprocess_line(char *p, char *bf, struct color_macro *macros)
 						break;
 					}
 				}
-				
+
 				bf[t] = ']';
-				
+
 				if (m) {
 					p = vsncpy(sv(p), sz(m->value));
 					i = t;
@@ -551,7 +551,7 @@ static char *preprocess_line(char *p, char *bf, struct color_macro *macros)
 			p = vsadd(p, bf[i]);
 		}
 	}
-	
+
 	return p;
 }
 
@@ -562,12 +562,12 @@ static int build_palette(COLORSET *cset, int startidx)
 	struct color_def *cdef;
 	int *palette = joe_malloc(SIZEOF(int) * SIZE);
 	int i, t;
-	
+
 	/* Clear start */
 	for (i = 0; i < startidx; i++) {
 		palette[i] = -1;
 	}
-	
+
 	/* Start adding from color defs */
 	i = startidx;
 	for (cdef = cset->alldefs; cdef; cdef = cdef->next) {
@@ -577,7 +577,7 @@ static int build_palette(COLORSET *cset, int startidx)
 			return 1;
 		}
 	}
-	
+
 	/* Add things from builtins */
 	for (t = 0; color_builtins[t].name; t++) {
 		if (add_palette(palette, &cset->builtins[t], &i, startidx, SIZE)) {
@@ -585,7 +585,7 @@ static int build_palette(COLORSET *cset, int startidx)
 			return 1;
 		}
 	}
-	
+
 	/* Add things from term colors */
 	for (t = 0; t < 16; t++) {
 		if (add_palette(palette, &cset->termcolors[t], &i, startidx, SIZE)) {
@@ -593,23 +593,23 @@ static int build_palette(COLORSET *cset, int startidx)
 			return 1;
 		}
 	}
-	
+
 	i = sort_palette(palette, startidx, i);
-	
+
 	/* Map back from the palette into attrs */
 	for (cdef = cset->alldefs; cdef; cdef = cdef->next)
 		get_palette(palette, &cdef->spec, startidx, i);
-	
+
 	for (t = 0; color_builtins[t].name; t++)
 		get_palette(palette, &cset->builtins[t], startidx, i);
-	
+
 	for (t = 0; t < 16; t++)
 		get_palette(palette, &cset->termcolors[t], startidx, i);
-	
+
 	/* Clear end */
 	for (t = i; t < SIZE; t++)
 		palette[t] = -1;
-	
+
 	cset->palette = palette;
 	return 0;
 }
@@ -619,7 +619,7 @@ static int add_palette(int *palette, struct color_spec *spec, int *idx, int star
 {
 	if (spec->type == COLORSPEC_TYPE_GUI) {
 		int i = *idx;
-		
+
 		/* This just keeps adding colors to the palette without checking if they're
 		   already there.  When it fills up, we sort and deduplicate, which resizes
 		   it down, and then we keep filling it.  This still winds up being faster
@@ -631,7 +631,7 @@ static int add_palette(int *palette, struct color_spec *spec, int *idx, int star
 			if (i >= size)
 				return 1;
 		}
-		
+
 		if (spec->mask & BG_MASK)
 			palette[i++] = spec->gui_bg;
 		if (i == size) {
@@ -639,10 +639,10 @@ static int add_palette(int *palette, struct color_spec *spec, int *idx, int star
 			if (i >= size)
 				return 1;
 		}
-		
+
 		*idx = i;
 	}
-	
+
 	return 0;
 }
 
@@ -650,13 +650,13 @@ static int add_palette(int *palette, struct color_spec *spec, int *idx, int star
 static int sort_palette(int *palette, int start, int end)
 {
 	int i, t;
-	
+
 	/* Sort */
 	jsort(&palette[start], end - start, SIZEOF(int), palcmp);
-	
+
 	/* Find first duplicate */
 	for (i = start + 1; i < end && palette[i - 1] != palette[i]; i++) { }
-	
+
 	/* Deduplicate */
 	for (t = i - 1; i < end; i++) {
 		for (; i < end && palette[t] == palette[i]; i++) { }
@@ -664,7 +664,7 @@ static int sort_palette(int *palette, int start, int end)
 			palette[++t] = palette[i];
 		}
 	}
-	
+
 	return t + 1;
 }
 
@@ -681,7 +681,7 @@ static void get_palette(int *palette, struct color_spec *spec, int startidx, int
 			spec->atr = (spec->atr & ~FG_MASK) | (findpal(palette, startidx, endidx, spec->gui_fg) << FG_SHIFT) | FG_TRUECOLOR | FG_NOT_DEFAULT;
 		if (spec->mask & BG_MASK)
 			spec->atr = (spec->atr & ~BG_MASK) | (findpal(palette, startidx, endidx, spec->gui_bg) << BG_SHIFT) | BG_TRUECOLOR | BG_NOT_DEFAULT;
-		
+
 		spec->type = COLORSPEC_TYPE_ATTR;
 	}
 }
@@ -691,7 +691,7 @@ static int findpal(int *palette, int startidx, int endidx, int color)
 {
 	int start = startidx;
 	int end = endidx - 1;
-	
+
 	while (start <= end) {
 		int mid = (start + end) / 2;
 		if (palette[mid] < color) {
@@ -702,7 +702,7 @@ static int findpal(int *palette, int startidx, int endidx, int color)
 			return mid;
 		}
 	}
-	
+
 	return -1;
 }
 
@@ -719,32 +719,32 @@ int apply_scheme(SCHEME *colors)
 	struct color_set *best = NULL, *p;
 	int i;
 	int supported = maint->t->truecolor ? 0x1000000 : (maint->t->assume_256 ? 256 : maint->t->Co);
-	
+
 	if (!colors)
 		return 1;
-	
+
 	/* Find matching set */
 	for (p = colors->sets; p; p = p->next) {
 		if (p->colors <= supported && (!best || best->colors < p->colors)) {
 			best = p;
 		}
 	}
-	
+
 	if (!best) {
 		/* No matching set found */
 		return 1;
 	}
-	
+
 	/* Apply builtins */
 	for (i = 0; color_builtins[i].name; i++) {
 		int defatr;
-		
+
 		/* Get default attribute */
 		if (color_builtins[i].default_ptr)
 			defatr = *color_builtins[i].default_ptr;
 		else
 			defatr = color_builtins[i].default_attr;
-		
+
 		if (best->builtins[i].type == COLORSPEC_TYPE_NONE) {
 			/* Use default */
 			if (color_builtins[i].attribute)
@@ -755,37 +755,37 @@ int apply_scheme(SCHEME *colors)
 			/* Take from scheme */
 			int atr = best->builtins[i].atr;
 			int mask = best->builtins[i].mask;
-			
+
 			/* Allow scheme to omit, e.g., background color */
 			atr = (mask & atr) | (~mask & ~AT_MASK & defatr);
-			
+
 			if (color_builtins[i].invert) {
 				atr = SWAP_COLOR(atr);
 				mask = SWAP_COLOR(mask);
 			}
-			
+
 			if (color_builtins[i].attribute) {
 				*color_builtins[i].attribute = atr;
 			}
-			
+
 			if (color_builtins[i].mask) {
 				*color_builtins[i].mask = ~mask;
 			}
 		}
 	}
-	
+
 	/* Apply colors to syntaxes and states */
 	for (stx = syntax_list; stx; stx = stx->next) {
 		resolve_syntax_colors(best, stx);
 	}
-	
+
 	curscheme = colors;
 	curschemeset = best;
 	scheme_name = curscheme->name;
-	
+
 	/* Apply palette */
 	setextpal(maint->t, best->palette);
-	
+
 	return 0;
 }
 
@@ -796,19 +796,19 @@ static void visit_colordef(COLORSET *cset, struct high_syntax *syntax, struct co
 
 	if (cdef->visited == COLORDEF_VISITED)
 		return;
-	
+
 	if (cdef->visited == COLORDEF_VISITING) {
 		logerror_2(joe_gettext(_("%s: Recursive color definition found involving %s\n")), syntax->name, cdef->name);
 		return;
 	}
-	
+
 	if (cdef->spec.type != COLORSPEC_TYPE_NONE) {
 		cdef->visited = COLORDEF_VISITED;
 		return;
 	}
-	
+
 	cdef->visited = COLORDEF_VISITING;
-	
+
 	/* Visit refs from this color */
 	for (cref = cdef->refs; cref; cref = cref->next) {
 		struct color_def *rcdef = NULL;
@@ -845,7 +845,7 @@ static void visit_colordef(COLORSET *cset, struct high_syntax *syntax, struct co
 			}
 		}
 	}
-	
+
 	cdef->visited = COLORDEF_VISITED;
 }
 
@@ -854,33 +854,33 @@ void resolve_syntax_colors(COLORSET *cset, struct high_syntax *syntax)
 {
 	int i;
 	struct color_def *scdef;
-	
+
 	/* Reset */
 	for (scdef = syntax->color; scdef; scdef = scdef->next) {
 		memset(&scdef->spec, 0, SIZEOF(struct color_spec));
 		scdef->spec.type = COLORSPEC_TYPE_NONE;
 		scdef->visited = 0;
 	}
-	
+
 	if (cset) {
 		/* Find colors from the scheme matching the syntax's class name. */
 		for (scdef = syntax->color; scdef; scdef = scdef->next) {
 			/* Is there a color by this one's name? */
 			struct color_def *cdef;
 			char buf[128];
-			
+
 			joe_snprintf_2(buf, SIZEOF(buf), "%s.%s", syntax->name, scdef->name);
 			cdef = htfind(cset->syntax, buf);
 			if (!cdef) {
 				cdef = htfind(cset->syntax, scdef->name);
 			}
-			
+
 			if (cdef) {
 				memcpy(&scdef->spec, &cdef->spec, SIZEOF(struct color_spec));
 				scdef->visited = COLORDEF_VISITED;
 			}
 		}
-		
+
 		/* Follow refs */
 		for (scdef = syntax->color; scdef; scdef = scdef->next) {
 			visit_colordef(cset, syntax, scdef);
@@ -913,11 +913,11 @@ void resolve_syntax_colors(COLORSET *cset, struct high_syntax *syntax)
 			}
 		}
 	}
-	
+
 	/* Propagate colors into the states */
 	for (i = 0; i < syntax->nstates; i++) {
 		struct high_state *st = syntax->states[i];
-		
+
 		if (st->colorp) {
 			st->color = st->colorp->spec.atr | (st->color & CONTEXT_MASK);
 		} else {
@@ -931,62 +931,62 @@ void dump_colors(BW *bw)
 {
 	char buf[256];
 	SCHEME *colors;
-	
+
 	for (colors = allcolors.link.next; colors != &allcolors; colors = colors->link.next) {
 		COLORSET *cset;
-		
+
 		joe_snprintf_1(buf, SIZEOF(buf), "Color scheme [%s]\n", colors->name);
 		binss(bw->cursor, buf);
 		pnextl(bw->cursor);
-		
+
 		for (cset = colors->sets; cset; cset = cset->next) {
 			struct color_def *cdef;
-			
+
 			joe_snprintf_1(buf, SIZEOF(buf), "* Color set [%d]\n", cset->colors);
 			binss(bw->cursor, buf);
 			pnextl(bw->cursor);
-			
+
 			if (cset->palette) {
 				int i;
-				
+
 				binss(bw->cursor, "  * Palette: ");
 				p_goto_eol(bw->cursor);
-				
+
 				/* Skip -1's */
 				for (i = 0; i < 256 && cset->palette[i] == -1; i++) { }
-				
+
 				/* Report start index */
 				joe_snprintf_1(buf, SIZEOF(buf), "[start %d] ", i);
 				binss(bw->cursor, buf);
 				p_goto_eol(bw->cursor);
-				
+
 				/* Write out palette */
 				for (; i < 256 && cset->palette[i] != -1; i++) {
 					joe_snprintf_1(buf, SIZEOF(buf), "%06x ", cset->palette[i]);
 					binss(bw->cursor, buf);
 					p_goto_eol(bw->cursor);
 				}
-				
+
 				binss(bw->cursor, "\n");
 				pnextl(bw->cursor);
 			}
-			
+
 			for (cdef = cset->alldefs; cdef; cdef = cdef->next) {
 				struct color_ref *cref;
-				
+
 				joe_snprintf_1(buf, SIZEOF(buf), "  * Color Definition [%s]\n", cdef->name);
 				binss(bw->cursor, buf);
 				pnextl(bw->cursor);
-				
+
 				for (cref = cdef->refs; cref; cref = cref->next) {
 					joe_snprintf_1(buf, SIZEOF(buf), "    * Color Reference [%s]\n", cref->name);
 					binss(bw->cursor, buf);
 					pnextl(bw->cursor);
 				}
 
-				joe_snprintf_3(buf, SIZEOF(buf), "    * Spec type=%d [%d/%d]\n", 
-					cdef->spec.type, 
-					(cdef->spec.atr & FG_MASK & ~FG_NOT_DEFAULT) >> FG_SHIFT, 
+				joe_snprintf_3(buf, SIZEOF(buf), "    * Spec type=%d [%d/%d]\n",
+					cdef->spec.type,
+					(cdef->spec.atr & FG_MASK & ~FG_NOT_DEFAULT) >> FG_SHIFT,
 					(cdef->spec.atr & BG_MASK & ~FG_NOT_DEFAULT) >> BG_SHIFT);
 				binss(bw->cursor, buf);
 				pnextl(bw->cursor);
@@ -1000,22 +1000,22 @@ void load_colors_state(FILE *fp)
 {
 	char buf[256];
 	char bf[256];
-	
+
 	while (fgets(buf, SIZEOF(buf)-1, fp) && zcmp(buf, "done\n")) {
 		const char *p = buf;
 		ptrdiff_t len;
 		char *term;
-		
+
 		parse_ws(&p, '#');
-		
+
 		/* Key */
 		term = NULL;
 		len = parse_string(&p, bf, SIZEOF(bf));
 		if (len <= 0) continue;
 		term = zdup(bf);
-		
+
 		parse_ws(&p, '#');
-		
+
 		/* Value */
 		len = parse_string(&p, bf, SIZEOF(bf));
 		if (len > 0) {
@@ -1035,7 +1035,7 @@ void save_colors_state(FILE *fp)
 {
 	struct color_states *st;
 	const char *myterm = getenv("TERM");
-	
+
 	for (st = saved_scheme_configs; st; st = st->next) {
 		if (zcmp(myterm, st->term)) {
 			fprintf(fp, "\t");
@@ -1045,7 +1045,7 @@ void save_colors_state(FILE *fp)
 			fprintf(fp, "\n");
 		}
 	}
-	
+
 	/* Save my scheme */
 	if (scheme_name) {
 		fprintf(fp, "\t");
@@ -1054,7 +1054,7 @@ void save_colors_state(FILE *fp)
 		emit_string(fp, scheme_name, zlen(scheme_name));
 		fprintf(fp, "\n");
 	}
-	
+
 	fprintf(fp, "done\n");
 }
 
@@ -1063,13 +1063,13 @@ int init_colors(void)
 {
 	const char *myterm = getenv("TERM");
 	struct color_states *st;
-	
+
 	/* Is one specified by global option? */
 	if (scheme_name) {
 		if (!apply_scheme(load_scheme(scheme_name)))
 			return 0;
 	}
-	
+
 	/* Search by terminal type */
 	for (st = saved_scheme_configs; st; st = st->next) {
 		if (st->term && !zcmp(st->term, myterm)) {
@@ -1077,7 +1077,7 @@ int init_colors(void)
 				return 0;
 		}
 	}
-	
+
 	/* Try default */
 	return apply_scheme(load_scheme("default"));
 }

--- a/joe/main.c
+++ b/joe/main.c
@@ -415,14 +415,9 @@ int main(int argc, char **real_argv, const char * const *envv)
 		}
 	}
 
-	/* User's joerc file */
-	s = getenv("HOME");
+	/* Find the user's JOERC file. */
+	s = get_joerc_path(run);
 	if (s) {
-		s = vsncpy(NULL, 0, sz(s));
-		s = vsncpy(sv(s), sc("/."));
-		s = vsncpy(sv(s), sv(run));
-		s = vsncpy(sv(s), sc("rc"));
-
 		if (!stat(s,&sbuf)) {
 			if (sbuf.st_mtime < time_rc) {
 				logmessage_2(joe_gettext(_("Warning: %s is newer than your %s.\n")),t,s);
@@ -432,6 +427,8 @@ int main(int argc, char **real_argv, const char * const *envv)
 		c = procrc(cap, s);
 		if (c == 0) {
 			vsrm(t);
+			joe_free(s);
+			s = NULL;
 			goto donerc;
 		}
 		if (c == 1) {
@@ -439,7 +436,7 @@ int main(int argc, char **real_argv, const char * const *envv)
 		}
 	}
 
-	vsrm(s);
+	joe_free(s);
 	s = t;
 	c = procrc(cap, s);
 	if (c == 0)

--- a/joe/rc.c
+++ b/joe/rc.c
@@ -1,7 +1,7 @@
 /*
  *	*rc file parser
  *	Copyright
- *		(C) 1992 Joseph H. Allen; 
+ *		(C) 1992 Joseph H. Allen;
  *
  *	This file is part of JOE (Joe's Own Editor)
  */
@@ -73,7 +73,7 @@ static MACRO *multiparse(JFILE *fd, int *refline, char *buf, ptrdiff_t *ofst, in
 	*referr = err;
 	*refline = line;
 	*ofst = x;
-	return m; 
+	return m;
 }
 
 /* Process rc file
@@ -375,133 +375,133 @@ int procrc(CAP *cap, char *name)
 /* Check to see if a joe resource file exists. If it does, return its path.
    If not, return NULL. */
 static char *try_get_joerc_file_path(const char *env_var, const char *rest_path, const char *file) {
-    char *var_path = env_var ? getenv(env_var) : "";
-    char *result;
-    const char *real_file = file ? file : "";
-    size_t result_len;
-    struct stat sb;
-    
-    if (!var_path || !rest_path)
-        return NULL;
+	char *var_path = env_var ? getenv(env_var) : "";
+	char *result;
+	const char *real_file = file ? file : "";
+	size_t result_len;
+	struct stat sb;
 
-    result_len = zlen(var_path) + zlen(rest_path) + zlen(real_file) + 1;
-    result = (char*)joe_malloc(result_len);
-    joe_snprintf_3(result, result_len, "%s%s%s", var_path, rest_path, real_file);
-    
-    if (stat(result, &sb)) {
-        joe_free(result);
-        return NULL;
-    }
+	if (!var_path || !rest_path)
+		return NULL;
 
-    return result;
+	result_len = zlen(var_path) + zlen(rest_path) + zlen(real_file) + 1;
+	result = (char*)joe_malloc(result_len);
+	joe_snprintf_3(result, result_len, "%s%s%s", var_path, rest_path, real_file);
+
+	if (stat(result, &sb)) {
+		joe_free(result);
+		return NULL;
+	}
+
+	return result;
 }
 
-/* Get a file path in the JOERC directory. If file is NULL get the directory 
-   itself. First checks $XDG_CONFIG_HOME/joe, then ~/.config/joe, and 
+/* Get a file path in the JOERC directory. If file is NULL get the directory
+   itself. First checks $XDG_CONFIG_HOME/joe, then ~/.config/joe, and
    finally ~/.joe. If no user JOERC dir exists, it check JOEDATA.
-   Returns NULL on failure. 
+   Returns NULL on failure.
    Returns a dynamically allocated string (path to the file) on success.
 */
 char *get_joerc_file_path(const char *file) {
-    char *result = try_get_joerc_file_path("XDG_CONF_HOME", "/joe/", file);
-    if (!result)
-        result = try_get_joerc_file_path("HOME", "/.config/joe/", file);
-    if (!result)
-        result = try_get_joerc_file_path("HOME", "/.joe/", file);
-    if (!result)
-        result = try_get_joerc_file_path(NULL, JOEDATA, file);
+	char *result = try_get_joerc_file_path("XDG_CONF_HOME", "/joe/", file);
+	if (!result)
+		result = try_get_joerc_file_path("HOME", "/.config/joe/", file);
+	if (!result)
+		result = try_get_joerc_file_path("HOME", "/.joe/", file);
+	if (!result)
+		result = try_get_joerc_file_path(NULL, JOEDATA, file);
 
-    return result;
+	return result;
 }
 
-/* Get joe's main resource file. 
+/* Get joe's main resource file.
    Run is argv[0].
-   Returns a dynmaically allocated path to the joerc. 
+   Returns a dynmaically allocated path to the joerc.
    Returns NULL on error.
 */
 char *get_joerc_path(const char *run) {
-    if (!run)
-        return NULL;
-    
-    size_t runrc_len = zlen(run) + sizeof("rc") + 2; /* 2 for NUL and possible prefix dot. */
-    char *runrc = (char*)joe_malloc(runrc_len);
+	if (!run)
+		return NULL;
 
-    joe_snprintf_2(runrc, runrc_len, "%s%s", run, "rc");
-    
-    char *result = try_get_joerc_file_path("XDG_CONF_HOME", "/joe/", runrc);
-    if (!result)
-        result = try_get_joerc_file_path("HOME", "/.config/joe/", runrc);
-    if (!result) {
-        joe_snprintf_2(runrc, runrc_len, ".%s%s", run, "rc");
-        result = try_get_joerc_file_path("HOME", "/", runrc);
-    }
+	size_t runrc_len = zlen(run) + sizeof("rc") + 2; /* 2 for NUL and possible prefix dot. */
+	char *runrc = (char*)joe_malloc(runrc_len);
 
-    joe_free(runrc);
-    return result;
+	joe_snprintf_2(runrc, runrc_len, "%s%s", run, "rc");
+
+	char *result = try_get_joerc_file_path("XDG_CONF_HOME", "/joe/", runrc);
+	if (!result)
+		result = try_get_joerc_file_path("HOME", "/.config/joe/", runrc);
+	if (!result) {
+		joe_snprintf_2(runrc, runrc_len, ".%s%s", run, "rc");
+		result = try_get_joerc_file_path("HOME", "/", runrc);
+	}
+
+	joe_free(runrc);
+	return result;
 }
 
 /* Load a cache file. */
 static FILE *load_cache_file(const char *env_prefix, const char *res_dir_path, const char *file_name, const char *mode) {
-    char *cachedir = getenv(env_prefix);
-    FILE *result;
-    mode_t old_mask;
-    size_t i;
-    size_t mode_len;
-    char *full_path = NULL;
-    size_t full_path_len;
-    
-    if (!cachedir || !mode)
-        return NULL;
+	char *cachedir = getenv(env_prefix);
+	FILE *result;
+	mode_t old_mask;
+	size_t i;
+	size_t mode_len;
+	char *full_path = NULL;
+	size_t full_path_len;
 
-    full_path_len = zlen(cachedir) + zlen(res_dir_path) + zlen(file_name) + 1;
-    full_path = (char*)joe_malloc(full_path_len);
-    joe_snprintf_3(full_path, full_path_len, "%s%s%s", cachedir, res_dir_path, file_name);
+	if (!cachedir || !mode)
+		return NULL;
 
-    /* Determine fopen options, if we write we umask. */
-    mode_len = zlen(mode);
-    for(i = 0; i < mode_len; i++) {
-        if(mode[i] == 'w' || mode[i] == '+' || mode[i] == 'a') {
-            old_mask = umask(0066);
-            result = fopen(full_path, "w");
-            umask(old_mask);
-            joe_free(full_path);
-            return result;
-        }
-    }
-    
-    result = fopen(full_path, "r");
-    joe_free(full_path);
-    return result;
+	full_path_len = zlen(cachedir) + zlen(res_dir_path) + zlen(file_name) + 1;
+	full_path = (char*)joe_malloc(full_path_len);
+	joe_snprintf_3(full_path, full_path_len, "%s%s%s", cachedir, res_dir_path, file_name);
+
+	/* Determine fopen options, if we write we umask. */
+	mode_len = zlen(mode);
+	for(i = 0; i < mode_len; i++) {
+		if(mode[i] == 'w' || mode[i] == '+' || mode[i] == 'a') {
+			old_mask = umask(0066);
+			result = fopen(full_path, "w");
+			umask(old_mask);
+			joe_free(full_path);
+			return result;
+		}
+	}
+
+	result = fopen(full_path, "r");
+	joe_free(full_path);
+	return result;
 }
 
-/* Get cache file of name NAME. Starts by checking XDG_CACHE_HOME, if no 
+/* Get cache file of name NAME. Starts by checking XDG_CACHE_HOME, if no
    dedicated cache dir is found, it will place the file into the joerc
    directory. If there is no JOERC directory, it will place the file
-   as a dotfile in the user's home. 
+   as a dotfile in the user's home.
    Returns a valid FILE* on success, returns NULL on error.
 */
 FILE *get_cache_file(const char *name, const char *mode) {
-    if (!name)
-        return NULL;
+	if (!name)
+		return NULL;
 
-    char *dotfile_name;
-    size_t dotfile_len;
+	char *dotfile_name;
+	size_t dotfile_len;
 
-    FILE *result = load_cache_file("XDG_CACHE_HOME", "/joe/", name, mode);
-    if (!result)
-        result = load_cache_file("HOME", "/.cache/joe/", name, mode);
-    if (!result)
-        result = load_cache_file("XDG_CONF_HOME", "/joe/", name, mode);
-    if (!result)
-        result = load_cache_file("HOME", "/.config/joe/", name, mode);
-    if (!result) {
-        dotfile_len = zlen(name) + 2;
-        dotfile_name = (char*)joe_malloc(dotfile_len);
-        joe_snprintf_1(dotfile_name, dotfile_len, ".%s", name);
-        result = load_cache_file("HOME", "/", dotfile_name, mode);
-        joe_free(dotfile_name);
-    }
+	FILE *result = load_cache_file("XDG_CACHE_HOME", "/joe/", name, mode);
+	if (!result)
+		result = load_cache_file("HOME", "/.cache/joe/", name, mode);
+	if (!result)
+		result = load_cache_file("XDG_CONF_HOME", "/joe/", name, mode);
+	if (!result)
+		result = load_cache_file("HOME", "/.config/joe/", name, mode);
+	if (!result) {
+		dotfile_len = zlen(name) + 2;
+		dotfile_name = (char*)joe_malloc(dotfile_len);
+		joe_snprintf_1(dotfile_name, dotfile_len, ".%s", name);
+		result = load_cache_file("HOME", "/", dotfile_name, mode);
+		joe_free(dotfile_name);
+	}
 
-    return result;
+	return result;
 }
 

--- a/joe/rc.h
+++ b/joe/rc.h
@@ -15,3 +15,26 @@ int procrc(CAP *cap, char *name);
 
 /* Validate rc file: return -1 if it's bad (call this after rc file has been loaded) */
 int validate_rc();
+
+/* Get a file path in the JOERC directory. If file is NULL get the directory 
+   itself. First checks $XDG_CONFIG_HOME/joe, then ~/.config/joe, and 
+   finally ~/.joe. If no user JOERC dir exists, it check JOEDATA.
+   Returns NULL on failure. 
+   Returns a dynamically allocated string (path to the file) on success.
+*/
+char *get_joerc_file_path(const char *file);
+
+/* Get joe's main resource file path. 
+   Run is argv[0].
+   Returns a dynmaically allocated path to the joerc.
+   Returns NULL on error.
+*/
+char *get_joerc_path(const char *run);
+
+/* Get cache file of name NAME. Starts by checking XDG_CACHE_HOME, if no 
+   dedicated cache dir is found, it will place the file into the joerc
+   directory. If there is no JOERC directory, it will place the file
+   as a dotfile in the user's home. 
+   Returns a valid FILE* on success, returns NULL on error.
+*/
+FILE *get_cache_file(const char *name, const char *mode);

--- a/joe/rc.h
+++ b/joe/rc.h
@@ -1,7 +1,7 @@
 /*
  *	*rc file parser
  *	Copyright
- *		(C) 1992 Joseph H. Allen; 
+ *		(C) 1992 Joseph H. Allen;
  *
  *	This file is part of JOE (Joe's Own Editor)
  */
@@ -16,25 +16,25 @@ int procrc(CAP *cap, char *name);
 /* Validate rc file: return -1 if it's bad (call this after rc file has been loaded) */
 int validate_rc();
 
-/* Get a file path in the JOERC directory. If file is NULL get the directory 
-   itself. First checks $XDG_CONFIG_HOME/joe, then ~/.config/joe, and 
+/* Get a file path in the JOERC directory. If file is NULL get the directory
+   itself. First checks $XDG_CONFIG_HOME/joe, then ~/.config/joe, and
    finally ~/.joe. If no user JOERC dir exists, it check JOEDATA.
-   Returns NULL on failure. 
+   Returns NULL on failure.
    Returns a dynamically allocated string (path to the file) on success.
 */
 char *get_joerc_file_path(const char *file);
 
-/* Get joe's main resource file path. 
+/* Get joe's main resource file path.
    Run is argv[0].
    Returns a dynmaically allocated path to the joerc.
    Returns NULL on error.
 */
 char *get_joerc_path(const char *run);
 
-/* Get cache file of name NAME. Starts by checking XDG_CACHE_HOME, if no 
+/* Get cache file of name NAME. Starts by checking XDG_CACHE_HOME, if no
    dedicated cache dir is found, it will place the file into the joerc
    directory. If there is no JOERC directory, it will place the file
-   as a dotfile in the user's home. 
+   as a dotfile in the user's home.
    Returns a valid FILE* on success, returns NULL on error.
 */
 FILE *get_cache_file(const char *name, const char *mode);

--- a/joe/state.c
+++ b/joe/state.c
@@ -8,7 +8,7 @@
 
 #include "types.h"
 
-/* Set to enable use of ~/.joe_state file */
+/* Set to enable use of joe_state file */
 int joe_state;
 
 /* Save a history buffer */
@@ -81,19 +81,15 @@ static void load_hist(FILE *f,B **bp)
 
 void save_state()
 {
-	char *home = getenv("HOME");
-	mode_t old_mask;
 	FILE *f;
+	char *joe_state_path;
 	if (!joe_state)
 		return;
-	if (!home)
-		return;
-	joe_snprintf_1(stdbuf,stdsiz,"%s/.joe_state",home);
-	old_mask = umask(0066);
-	f = fopen(stdbuf,"w");
-	umask(old_mask);
-	if(!f)
-		return;
+
+	f = get_cache_file("joe_state", "w");
+
+	if (!f)
+	   return;
 
 	/* Write ID */
 	fprintf(f,"%s",STATE_ID);
@@ -119,15 +115,11 @@ void save_state()
 
 void load_state()
 {
-	char *home = getenv("HOME");
 	char buf[1024];
 	FILE *f;
 	if (!joe_state)
 		return;
-	if (!home)
-		return;
-	joe_snprintf_1(stdbuf,stdsiz,"%s/.joe_state",home);
-	f = fopen(stdbuf,"r");
+	f = get_cache_file("joe_state", "r");
 	if(!f)
 		return;
 

--- a/joe/syntax.c
+++ b/joe/syntax.c
@@ -730,18 +730,18 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 	int line = 0;
 	int this_one = 0;
 	int inside_subr = 0;
+	char *syntax_path;
 
 	/* Load it */
-	p = getenv("HOME");
-	if (p) {
-		joe_snprintf_2(name,SIZEOF(name),"%s/.joe/syntax/%s.jsf",p,syntax->name);
-		f = jfopen(name,"r");
+	joe_snprintf_1(name, SIZEOF(name), "syntax/%s.jsf", syntax->name);
+	syntax_path = get_joerc_file_path(name);
+
+	if (syntax_path)
+	{
+		f = jfopen(syntax_path, "r");
+		joe_free(syntax_path);
 	}
 
-	if (!f) {
-		joe_snprintf_2(name,SIZEOF(name),"%ssyntax/%s.jsf",JOEDATA,syntax->name);
-		f = jfopen(name,"r");
-	}
 	if (!f) {
 		joe_snprintf_1(name,SIZEOF(name),"*%s.jsf",syntax->name);
 		f = jfopen(name,"r");


### PR DESCRIPTION
[Sourceforge patch 127: Support for ~/.config](https://sourceforge.net/p/joe-editor/patches/127/) by Ryan Jeffrey

I have created a patch that adds support for modern .config directories for config files. ~/.config/joe/joerc for example is where the joerc is, ~/.config/joe/syntax for jsf files, etc.. Also supports XDG_CONFIG_HOME. Moves joe_state to ~/.cache/joe if the directory exists. Old paths for all files still supported. 