### PR TITLE
SF Patches 122-123: Syntax delimiter stack and Python f-strings

### DIFF
--- a/joe/syntax.h
+++ b/joe/syntax.h
@@ -35,6 +35,10 @@ struct high_cmd {
 	unsigned stop_buffering : 1;	/* Set if we should stop buffering */
 	unsigned save_c : 1;		/* Save character */
 	unsigned save_s : 1;		/* Save string */
+	unsigned push_c : 1;		/* Push character */
+	unsigned push_s : 1;		/* Push string */
+	unsigned pop_c : 1;		/* Push character */
+	unsigned pop_s : 1;		/* Push string */
 	unsigned ignore : 1;		/* Set to ignore case */
 	unsigned start_mark : 1;	/* Set to begin marked area including this char */
 	unsigned stop_mark : 1;		/* Set to end marked area excluding this char */
@@ -58,20 +62,30 @@ struct high_frame {
 	struct high_state *return_state;	/* Return state in the caller's subroutine */
 };
 
+/* delimiter stack frame */
+
+struct high_delim_frame {
+	struct high_delim_frame *parent;	/* Previous pushed delimiter buffer */
+	struct high_delim_frame *child;		/* Next pushed delimiter buffer */
+	struct high_delim_frame *sibling;	/* Another pushed delimiter buffer at the same level */
+	const int *saved_s;			/* Pushed delimiter buffer */
+};
+
 /* Loaded form of syntax file or subroutine */
 
 struct high_syntax {
-	struct high_syntax *next;	/* Linked list of loaded syntaxes */
-	char *name;			/* Name of this syntax */
-	char *subr;			/* Name of the subroutine (or NULL for whole file) */
-	struct high_param *params;	/* Parameters defined */
-	struct high_state **states;	/* The states of this syntax.  states[0] is idle state */
-	HASH *ht_states;		/* Hash table of states */
-	ptrdiff_t nstates;		/* No. states */
-	ptrdiff_t szstates;		/* Malloc size of states array */
-	struct color_def *color;	/* Linked list of color definitions */
-	struct high_cmd default_cmd;	/* Default transition for new states */
-	struct high_frame *stack_base;  /* Root of run-time call tree */
+	struct high_syntax *next;			/* Linked list of loaded syntaxes */
+	char *name;					/* Name of this syntax */
+	char *subr;					/* Name of the subroutine (or NULL for whole file) */
+	struct high_param *params;			/* Parameters defined */
+	struct high_state **states;			/* The states of this syntax.  states[0] is idle state */
+	HASH *ht_states;				/* Hash table of states */
+	ptrdiff_t nstates;				/* No. states */
+	ptrdiff_t szstates;				/* Malloc size of states array */
+	struct color_def *color;			/* Linked list of color definitions */
+	struct high_cmd default_cmd;			/* Default transition for new states */
+	struct high_frame *stack_base;			/* Root of run-time call tree */
+	struct high_delim_frame *delim_stack_base;	/* Root of run-time delimiter buffer tree */
 };
 
 /* Find a syntax.  Load it if necessary. */
@@ -83,10 +97,10 @@ struct high_syntax *load_syntax(const char *name);
 HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE state,struct charmap *charmap);
 extern int *attr_buf;
 
-#define clear_state(s) (((s)->saved_s = 0), ((s)->state = 0), ((s)->stack = 0))
-#define invalidate_state(s) (((s)->state = -1), ((s)->saved_s = 0), ((s)->stack = 0))
+#define clear_state(s) (((s)->saved_s = 0), ((s)->state = 0), ((s)->stack = 0), ((s)->delim_stack = 0))
+#define invalidate_state(s) (((s)->state = -1), ((s)->saved_s = 0), ((s)->stack = 0), ((s)->delim_stack = 0))
 #define move_state(to,from) (*(to)= *(from))
-#define eq_state(x,y) ((x)->state == (y)->state && (x)->stack == (y)->stack && (x)->saved_s == (y)->saved_s)
+#define eq_state(x,y) ((x)->state == (y)->state && (x)->stack == (y)->stack && (x)->delim_stack == (y)->delim_stack && (x)->saved_s == (y)->saved_s)
 
 extern struct high_syntax *syntax_list;
 

--- a/joe/types.h
+++ b/joe/types.h
@@ -280,6 +280,7 @@ typedef struct color_scheme SCHEME;
 
 struct highlight_state {
 	struct high_frame *stack; /* Pointer to the current frame in the call stack */
+	struct high_delim_frame *delim_stack; /* Pointer to the previously pushed delimiter buffer */
 	const int *saved_s; /* Interned Z-string for saved delimiter */
 	ptrdiff_t state; /* Current state in the current subroutine */
 };

--- a/syntax/c.jsf
+++ b/syntax/c.jsf
@@ -69,6 +69,17 @@
 #
 #   save_s      Copy string buffer to delimiter match buffer.
 #
+#   push_c	Push the delimiter match buffer onto the delimiter stack and
+#		save character in delimiter match buffer.
+#
+#   push_s	Push the delimiter match buffer onto the delimiter stack and
+#		copy string buffer to delimiter match buffer.
+#
+#   pop_c	Pop the delimiter stack into the delimiter match buffer.
+#
+#   pop_s	Pop the delimiter stack into the delimiter match buffer.
+#		(functionally identical to pop_c)
+#
 #   strings	A list of strings follows.  If the buffer matches any of the
 #		given strings, a jump to the target-state in the string list
 #		is taken instead of the normal jump.

--- a/syntax/jsf.jsf
+++ b/syntax/jsf.jsf
@@ -351,6 +351,10 @@
 	"buffer"	option_color
 	"save_c"	option_color
 	"save_s"	option_color
+	"push_c"	option_color
+	"push_s"	option_color
+	"pop_c"		option_color
+	"pop_s"		option_color
 	"hold"		option_color
 	"call"		call_color
 	"return"	option_color
@@ -366,6 +370,10 @@
 	"buffer"	option_color
 	"save_c"	option_color
 	"save_s"	option_color
+	"push_c"	option_color
+	"push_s"	option_color
+	"pop_c"		option_color
+	"pop_s"		option_color
 	"strings"	strings_color
 	"istrings"	strings_color
 	"hold"		option_color

--- a/syntax/python.jsf
+++ b/syntax/python.jsf
@@ -27,14 +27,46 @@
 =Decorator	+Define +Preproc
 =Builtin	+DefinedFunction
 
+=FstringBrace	+Brace
+
 :idle Idle
 	*		idle
 	"#"		comment		recolor=-1
 	"0-9"		first_digit	recolor=-1
-	"'\""		string_quot_1	recolor=-1 save_c
 	"\i"		ident		noeat
+	"'\""		string_quot_1	recolor=-1 push_c
+.ifdef fstring
+.ifdef docstring
+	&		doc_end_quot_1	recolor=-1 push_c
+.else
+	&		idle		noeat return
+.endif
+	":"		idle		noeat return
+	"{"		fstring_brace	recolor=-1
+	"}"		idle		noeat return
+.else
 	"{}"		brace		recolor=-1
+.endif
 	"@"		decorator	recolor=-1
+
+.ifdef fstring
+:fstring_brace FstringBrace
+	*		return_from_expr	noeat call=python()
+
+:return_from_expr FstringBrace
+	*		return_from_expr	noeat return
+	"}"		idle
+
+.ifdef docstring
+:doc_end_quot_1 String string
+	*		string_quot_1	noeat
+	&		doc_end_quot_2	pop_c
+
+:doc_end_quot_2 String string
+	*		idle		noeat
+	&		idle		noeat return
+.endif
+.endif
 
 :brace Brace
 	*		idle		noeat
@@ -205,6 +237,9 @@ done
 	"r"		string_raw_pre
 	"br"		string_raw_pre
 	"rb"		string_raw_pre
+	"f"		string_fstring_pre
+	"fr"		string_raw_fstring_pre
+	"rf"		string_raw_fstring_pre
 done
 	"\c"		ident1
 
@@ -260,15 +295,23 @@ done
 # Handle string prefixes up to the string itself.
 :string_pre String string
 	*		idle noeat
-	"'\""		string_quot_1 	save_c
+	"'\""		string_quot_1 	push_c
 
 :string_raw_pre String string
 	*		idle noeat
-	"'\""		string_quot_raw_1 save_c
+	"'\""		string_quot_raw_1 push_c
+
+:string_fstring_pre String string
+	*		idle noeat
+	"'\""		string_quot_fstring_1 	push_c
+
+:string_raw_fstring_pre String string
+	*		idle noeat
+	"'\""		string_quot_raw_fstring_1 push_c
 
 # Differentiate between docstrings and regular strings, carrying with it raw state
 :string_quot_1 String string
-	*		idle call=.string() noeat
+	*		idle call=.string(-docstring) noeat
 	&		string_quot_2
 
 :string_quot_2 String string
@@ -276,12 +319,28 @@ done
 	&		idle call=.string(docstring) recolor=-3
 
 :string_quot_raw_1 String string
-	*		idle call=.string(raw)
+	*		idle call=.string(-docstring raw)
 	&		string_quot_raw_2
 
 :string_quot_raw_2 String string
 	*		idle noeat
 	&		idle call=.string(docstring raw) recolor=-3
+
+:string_quot_fstring_1 String string
+	*		idle call=.string(-docstring fstring) noeat
+	&		string_quot_fstring_2
+
+:string_quot_fstring_2 String string
+	*		idle noeat
+	&		idle call=.string(docstring fstring) recolor=-3
+
+:string_quot_raw_fstring_1 String string
+	*		idle call=.string(-docstring raw fstring)
+	&		string_quot_raw_fstring_2
+
+:string_quot_raw_fstring_2 String string
+	*		idle noeat
+	&		idle call=.string(docstring raw fstring) recolor=-3
 
 .subr string
 
@@ -293,6 +352,10 @@ done
 .else
 	"\\"		string_esc	mark
 .endif
+.ifdef fstring
+	"{"		fstring_maybe_expr	recolor=-1
+	"}"		fstring_esc_or_bad	recolor=-1 mark
+.endif
 	&		doc_end_1
 
 :doc_end_1 Docstring string
@@ -301,18 +364,22 @@ done
 
 :doc_end_2 Docstring string
 	*		string noeat
-	&		string return
+	&		string return pop_c
 
 .else			# Short strings
 
 :string String string
 	*		string
-	"\n"		string return
+	"\n"		string return pop_c
 .ifdef raw
 .else
 	"\\"		string_esc mark
 .endif
-	&		string return
+.ifdef fstring
+	"{"		fstring_maybe_expr	recolor=-1
+	"}"		fstring_esc_or_bad	recolor=-1 mark
+.endif
+	&		string return pop_c
 
 .endif
 
@@ -323,10 +390,64 @@ done
 	"U"		string_hex8
 	"0-7"		string_octal2
 	"\n"		string_esc_done
+.ifdef fstring
+	"{"		fstring_esc_maybe_expr	recolor=-1
+.endif
+
+.ifdef fstring
+:fstring_esc_maybe_expr FstringBrace
+	*		fstring_maybe_expr	noeat
+	"{"		string_esc_really_done	recolor=-2
+
+:fstring_maybe_expr FstringBrace
+	*		fstring_maybe_end	noeat call=python()
+	"{"		string_esc_really_done	recolor=-2
+
+:fstring_maybe_end FstringBrace
+	*		string			noeat
+.ifdef docstring
+	&		doc_end_2		noeat recolor=-3
+.endif
+	"}"		string
+	":"		fstring_format
+
+:fstring_format Constant
+	*		fstring_format
+	"{"		fstring_format_fstring	recolor=-1
+	"}"		fstring_maybe_end	noeat
+
+:fstring_format_fstring FstringBrace
+	*		fstring_format_fstring_maybe_end	noeat call=python()
+
+:fstring_format_fstring_maybe_end FstringBrace
+	*		string			noeat
+.ifdef docstring
+	&		doc_end_2		noeat recolor=-3
+.endif
+	"}"		fstring_format
+	":"		fstring_format_fstring_format
+
+:fstring_format_fstring_format Constant
+	*		fstring_format_fstring_format
+	"{"		fstring_esc_or_bad			recolor=-1 # Too deep
+	"}"		fstring_format_fstring_format_end	recolor=-1
+
+:fstring_format_fstring_format_end FstringBrace
+	*		fstring_format		noeat
+.endif
 
 # Recolor whole escape sequence based on whether this is a docstring.
 :string_esc_done String string
 	*		string_esc_really_done noeat markend recolormark
+
+.ifdef fstring
+:fstring_esc_or_bad Bad string
+	*		string			noeat
+	"}"		fstring_esc
+
+:fstring_esc String string
+	*		string_esc_really_done	noeat markend recolormark
+.endif
 
 .ifdef docstring
 :string_esc_really_done DocEscape


### PR DESCRIPTION
Combining two patches due to very close relation:

[Sourceforge Patch 122: delimiter stack](https://sourceforge.net/p/joe-editor/patches/122/) by Charles J. Tabony

Hi! I was trying to update the syntax highlighting for Python to properly highlight f-strings, and it got... complicated. At least, it got complicated when I tried to handle nested f-strings. One problem is that you can have four types of strings, all nested, some of which use double quotes as their delimiter and some single quotes. You could keep track of all of this using call parameters, but like I said, it was getting complicated.

I realized that it would be very handy to have a stack of delimiter match buffers similar to the stack of subroutines. So I decided to add that feature. Here it is.

Here's an example syntax file that uses the feature:

```
=Idle
=Bad

:idle Idle
* idle
"([{<" idle push_c
")]}>" bad noeat
& idle pop_c

:bad Bad
* idle
```

If you use it (and a patched JOE) to highlight the following:

`<<{[(())]}>)`

then the last `)` will be highlighted as Bad. (It can only highlight closing brackets that are unmatched since the state machine doesn't work backwards.)

[Sourceforge Patch 123: Python f-strings](https://sourceforge.net/p/joe-editor/patches/123/) by Charles J. Tabony

This patch only works with patch [[#122]](https://sourceforge.net/p/joe-editor/patches/122/). It augments the Python syntax highlighting to hightlight f-strings nicely. It handles nesting of f-strings and escapes and raw strings and all that. Try using it to hightlight the following:

```python
x=2
print( f"""\\\{{{f'{{x}}=={ {x} }'}}}""")
print(rf"""\\\{{{f'{{x}}=={ {x} }'}}}""")
print( f"""\\\{{{f'{{f"{{x:02}}"}}=={ {f"{x:02}"} }'}}}""")
# Output:
# \\{{x}=={2}}
# \\\{{x}=={2}}
# \\{{f"{x:02}"}=={'02'}}

# Syntax errors:
f' { '
f' } '
```