### PR TITLE
SF Patch 121: Recognition of latin10 as an alias to ISO-8859-16

### DIFF
--- a/joe/charmap.c
+++ b/joe/charmap.c
@@ -128,6 +128,7 @@ static struct {
 	{ "latin7", "iso-8859-13" },
 	{ "latin8", "iso-8859-14" },
 	{ "latin9", "iso-8859-15" },
+	{ "latin10", "iso-8859-16" },
 	{ 0, 0 }
 };
 


### PR DESCRIPTION
[Sourceforge Patch 121: Recognition of latin10 as an alias to ISO-8859-16] by IF_

ISO-8859-16 should be aliased as latin10 following the similar convention of informal naming applied to other character sets comprising the standard.