### PR TITLE
Fix SF-287: protect crontab files from -break_links

### DIFF
--- a/rc/ftyperc
+++ b/rc/ftyperc
@@ -924,3 +924,10 @@
 -syntax haskell
 -vhdl_comment
 -highlighter_context
+
+ Crontabs
+[crontab]
+*crontab
+--break_hardlinks
+--break_links
+


### PR DESCRIPTION
Using suggested fix from [SF-287](https://sourceforge.net/p/joe-editor/bugs/287/)