### PR TITLE
Don't record empty macros; clear them instead.

### DIFF
--- a/joe/macro.c
+++ b/joe/macro.c
@@ -597,12 +597,18 @@ int ustop(W *w, int k)
 	if (recmac) {
 		struct recmac *r = recmac;
 		MACRO *m;
+		/* true if the macro is effectively empty (contains only "stop") */
+		int empty = recmac->m->steps[0]->cmd->func == ustop;
 
 		dostaupd = 1;
 		recmac = r->next;
 		if (kbdmacro[r->n])
 			rmmacro(kbdmacro[r->n]);
-		kbdmacro[r->n] = r->m;
+		if (empty) {
+			kbdmacro[r->n] = NULL;
+			rmmacro(r->m);
+		} else
+			kbdmacro[r->n] = r->m;
 		if (recmac)
 			record(m = mkmacro(r->n + '0', 0, 0, findcmd("play")), NO_MORE_DATA), rmmacro(m);
 		joe_free(r);


### PR DESCRIPTION
No point in keeping an empty macro around or in writing it to `~/.joe_state`, so just drop it at creation time.