### PR TITLE
Guard against missing jump targets in syntax highlighting.

### DIFF
--- a/joe/bw.c
+++ b/joe/bw.c
@@ -371,10 +371,10 @@ static struct state_debug_data out_osc8(const struct state_debug_data *oldstate,
 			if (oldstate->name == newstate->name)
 				return *oldstate;
 
-			if (oldstate->name)
+			if (oldstate->name >= 0)
 				ttputs("\x1B]8;;\x1B\\");
 
-			if (newstate) {
+			if (newstate && newstate->name >= 0) {
 				ttputs("\x1B]8;id=");
 				ttputs(state_names[newstate->name]);
 				ttputs(";");
@@ -389,7 +389,7 @@ static struct state_debug_data out_osc8(const struct state_debug_data *oldstate,
 			if (oldstate->recolor)
 				ttputs("\x1B]8;;\x1B\\");
 
-			if (newstate) {
+			if (newstate && newstate->name >= 0) {
 				ttputs("\x1B]8;id=");
 				ttputs(newstate->recolor ? state_names[newstate->recolor] : "(idle)");
 				ttputs(";");
@@ -401,10 +401,10 @@ static struct state_debug_data out_osc8(const struct state_debug_data *oldstate,
 			if (oldstate->name == newstate->name && oldstate->recolor == newstate->recolor)
 				return *oldstate;
 
-			if (oldstate->name || oldstate->recolor)
+			if (oldstate->name >= 0 || oldstate->recolor >= 0)
 				ttputs("\x1B]8;;\x1B\\");
 
-			if (newstate) {
+			if (newstate && newstate->name >= 0) {
 				ttputs("\x1B]8;id=");
 				ttputs(state_names[newstate->name]);
 				ttputs(";");
@@ -422,7 +422,7 @@ static struct state_debug_data out_osc8(const struct state_debug_data *oldstate,
 
 static void end_osc8(const struct state_debug_data *oldstate, int opt)
 {
-	if ((opt & 1 && oldstate->name) || (opt & 2 && oldstate->recolor))
+	if ((opt & 1 && oldstate->name >= 0) || (opt & 2 && oldstate->recolor >= 0))
 		ttputs("\x1B]8;;\x1B\\");
 }
 #define OUT_osc8(bw,os,ns) ((bw)->b->o.syntax_debug ? out_osc8(&(os), &(ns), (bw)->b->o.syntax_debug) : (os))

--- a/joe/syntax.c
+++ b/joe/syntax.c
@@ -263,7 +263,10 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 			if (iters++ > state_count) {
 			      error_invalidate_return:
 				invalidate_state(&h_state);
+				/* remainder of these two buffers has unknown content - clear it */
 				memset(attr, 0, (attr_end - attr) * sizeof(*attr));
+				if (syndebug)
+					memset(syndebug, 255, (attr_end - attr) * sizeof(*syndebug)); /* set to -1 */
 				return h_state;
 			}
 


### PR DESCRIPTION
A syntax colouring rule without a jump target would, if matched, cause this:

Program received signal SIGSEGV, Segmentation fault. parse (syntax=0x55e36a0749b0, line=line@entry=0x55e36a06a280, h_state=...,
    charmap=0x55e369f76520) at ./joe/syntax.c:231
231				attr[-1] = h->color;

h is null at this point.