### PR TITLE
fix: Add CSIu sequences for ^I and ^M

### DIFF
--- a/rc/jicerc.ru.in
+++ b/rc/jicerc.ru.in
@@ -776,6 +776,7 @@ querysave,query,killjoe	^K q
 arg		^K \		Повтор следующей команды 
 explode		^K I		Показывать все окна или только одно
 explode		^K ^I
+explode		^K ^[ [ 1 0 5 ; 5 u
 explode		^K i
 help		.k1
 help		.k8
@@ -794,6 +795,7 @@ hprev		^P  		Предыдущая страница подсказки
 math		^[ m		Калькулятор
 math		^[ M		Калькулятор
 math		^[ ^M		Калькулятор
+math		^[ ^[ [ 1 0 9 ; 5 u
 msg		^[ h		Вывод сообщения
 msg		^[ H		Вывод сообщения
 msg		^[ ^H		Вывод сообщения
@@ -818,6 +820,7 @@ query		^K ?		Macro query insert
 record		^K [		Записать макро
 retype		^R		Перерисовка экрана
 rtn		^M		Перевод строки
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^K Z		Выход в шелл
 shell		^K ^Z
 shell		^K z
@@ -939,7 +942,9 @@ execmd		^[ X
 execmd		^[ ^X		
 jump		^[ SP
 finish		^[ ^I		Complete word in document
+finish		^[ ^[ [ 1 0 5 ; 5 u
 finish		^[ ^M		Complete word: used to be math
+finish		^[ ^[ [ 1 0 9 ; 5 u
 isrch		^[ s		Инкрементальный поиск вперед
 isrch		^[ S		
 isrch		^[ ^S		
@@ -1026,6 +1031,7 @@ blkdel		^K y
 blkmove		^K M		Переместить блок
 blkmove		.k6 		
 blkmove		^K ^M
+blkmove		^K ^[ [ 1 0 9 ; 5 u
 blkmove		^K m
 blksave		.f5 		Сохранить блок
 blksave		.F5 		
@@ -1077,6 +1083,7 @@ ffirst		^K ^F
 ffirst		^K f
 filt		^K /		Фильтровать блок
  finish		^K ^M		Complete text under cursor
+ finish		^K ^[ [ 1 0 9 ; 5 u
 fnext		.k7     	Поиск дальше
 fnext		^L		
 fmtblk		^K J		Форматировать абзац в блоке
@@ -1170,6 +1177,7 @@ shell4		.k4
 :inherit main
 if,"byte>size",then,complete,complete,else,delch,endif	^D
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^N
 dnarw,eol	^[ O B
@@ -1216,10 +1224,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1241,8 +1251,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1260,6 +1272,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/jmacsrc.in
+++ b/rc/jmacsrc.in
@@ -707,6 +707,7 @@ query		^X Q		Query insert
 record,"0"	^X (		Record macro
 retype		^L		Refresh screen
 rtn		^M		Return
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^Z		Suspend
 shell		^[ s		Suspend (uemacs)
 shell		^[ S		Suspend (uemacs)
@@ -1114,6 +1115,7 @@ redo		^^		Redo changes
 rsrch		^R		Incremental search backwards
 
 indentregion	^X ^I
+indentregion	^X ^[ [ 1 0 5 ; 5 u
 indentregion	^[ ^\
  markk,rindent	^[ ^\
 rtarw		.kr		Go right
@@ -1174,6 +1176,7 @@ shell4		.k4
 abort		^G
 abort		^C
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^N
 dnarw,eol	^[ O B
@@ -1243,10 +1246,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^X H
 rtn		^X h
 rtn		^X ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1268,8 +1273,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1287,6 +1294,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -787,6 +787,7 @@ abort		^K q
 arg		^K \		Repeat next command
 explode		^K I		Show all windows or show only one window
 explode		^K ^I
+explode		^K ^[ [ 1 0 5 ; 5 u
 explode		^K i
 help		^K H		Help menu
 help		^K ^H
@@ -796,6 +797,7 @@ hprev		^[ ,		Previous help window
 math		^[ m		Calculator
 math		^[ M		Calculator
  math		^[ ^M		Calculator
+ math		^[ ^[ [ 1 0 9 ; 5 u
 msg		^[ h		Display a message
 msg		^[ H		Display a message
 msg		^[ ^H		Display a message
@@ -819,6 +821,7 @@ record		^K [		Record a macro
  retype		^R		Refresh screen
  recenter	^R		Recenter and refresh screen
 rtn		^M		Return
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^K Z		Shell escape
 shell		^K ^Z
 shell		^K z
@@ -975,7 +978,9 @@ execmd		^[ x		Prompt for command to execute
 execmd		^[ X		Prompt for command to execute
 execmd		^[ ^X		Prompt for command to execute
 finish		^[ ^I		Complete word in document
+finish		^[ ^[ [ 1 0 5 ; 5 u
 finish		^[ ^M		Complete word: used to be math
+finish		^[ ^[ [ 1 0 9 ; 5 u
 mwind!,mfit,jump,bol		^[ SP
 isrch		^[ s		Forward incremental search
 isrch		^[ S		Forward incremental search
@@ -1060,6 +1065,7 @@ blkdel		^K ^Y
 blkdel		^K y
 blkmove		^K M		Move marked block
 blkmove		^K ^M
+blkmove		^K ^[ [ 1 0 9 ; 5 u
 blkmove		^K m
 blksave		^K W		Save marked block
 blksave		^K ^W
@@ -1106,6 +1112,7 @@ ffirst		^K ^F
 ffirst		^K f
 filt		^K /		Filter block
  finish		^K ^M		Complete text under cursor
+ finish		^K ^[ [ 1 0 9 ; 5 u
 fnext		^L		Find next
 fmtblk		^K J		Format paragraphs in block
 fmtblk		^K ^J
@@ -1196,6 +1203,7 @@ shell4		.k4
 :inherit main
 if,"byte>size",then,complete,complete,else,delch,endif	^D
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^N
 dnarw,eol	^[ O B
@@ -1265,10 +1273,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1291,8 +1301,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1310,6 +1322,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/joerc.zh_TW.in
+++ b/rc/joerc.zh_TW.in
@@ -736,6 +736,7 @@ abort		^K q
 arg		^K \		Repeat next command
 explode		^K I		Show all windows or show only one window
 explode		^K ^I
+explode		^K ^[ [ 1 0 5 ; 5 u
 explode		^K i
 help		^K H		Help menu
 help		^K ^H
@@ -745,6 +746,7 @@ hprev		^[ ,		Previous help window
 math		^[ m		Calculator
 math		^[ M		Calculator
  math		^[ ^M		Calculator
+ math		^[ ^[ [ 1 0 9 ; 5 u
 msg		^[ h		Display a message
 msg		^[ H		Display a message
 msg		^[ ^H		Display a message
@@ -767,6 +769,7 @@ query		^K ?		Macro query insert
 record		^K [		Record a macro
 retype		^R		Refresh screen
 rtn		^M		Return
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^K Z		Shell escape
 shell		^K ^Z
 shell		^K z
@@ -921,7 +924,9 @@ execmd		^[ x		Prompt for command to execute
 execmd		^[ X		Prompt for command to execute
 execmd		^[ ^X		Prompt for command to execute
 finish		^[ ^I		Complete word in document
+finish		^[ ^[ [ 1 0 5 ; 5 u
 finish		^[ ^M		Complete word: used to be math
+finish		^[ ^[ [ 1 0 9 ; 5 u
 mwind!,mfit,jump,bol		^[ SP
 isrch		^[ s		Forward incremental search
 isrch		^[ S		Forward incremental search
@@ -1004,6 +1009,7 @@ blkdel		^K ^Y
 blkdel		^K y
 blkmove		^K M		Move marked block
 blkmove		^K ^M
+blkmove		^K ^[ [ 1 0 9 ; 5 u
 blkmove		^K m
 blksave		^K W		Save marked block
 blksave		^K ^W
@@ -1048,6 +1054,7 @@ ffirst		^K ^F
 ffirst		^K f
 filt		^K /		Filter block
  finish		^K ^M		Complete text under cursor
+ finish		^K ^[ [ 1 0 9 ; 5 u
 fnext		^L		Find next
 fmtblk		^K J		Format paragraphs in block
 fmtblk		^K ^J
@@ -1138,6 +1145,7 @@ shell4		.k4
 :inherit main
 if,"byte>size",then,complete,complete,else,delch,endif	^D
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^N
 dnarw,eol	^[ O B
@@ -1207,10 +1215,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1233,8 +1243,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1252,6 +1264,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/jpicorc.in
+++ b/rc/jpicorc.in
@@ -697,6 +697,7 @@ abort		^C		Abort window
 arg		^[ \		Repeat next command
 explode		^[ I		Show all windows or show only one window
 explode		^[ ^I
+explode		^[ ^[ [ 1 0 5 ; 5 u
 explode		^[ i
 help		^G		Help menu
 help		.k1
@@ -705,6 +706,7 @@ hprev		^[ ,		Previous help window
 math		^[ m		Calculator
 math		^[ M		Calculator
 math		^[ ^M		Calculator
+math		^[ ^[ [ 1 0 9 ; 5 u
 nextw		^[ N		Goto next window
 nextw		^[ ^N
 nextw		^[ n
@@ -724,6 +726,7 @@ query		^[ ?		Macro query insert
 record		^[ (		Record a macro
 retype		^L		Refresh screen
 rtn		^M		Return
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^[ z
 shell		^[ Z
 shell		^[ ^Z
@@ -959,6 +962,7 @@ shell4		.k4
 :inherit main
 abort		^C
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 cancel,bof	^Y
 cancel,eof	^V
 cancel,line	^T
@@ -1033,10 +1037,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1058,8 +1064,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1077,6 +1085,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/jstarrc.in
+++ b/rc/jstarrc.in
@@ -683,6 +683,7 @@ arg		^Q ^Q
 arg		^Q q
 explode		^K I
 explode		^K ^I
+explode		^K ^[ [ 1 0 5 ; 5 u
 explode		^K i
 help		^J
 nmark		^K H
@@ -692,6 +693,7 @@ hnext		^[ .
 hprev		^[ ,
 math		^Q M
 math		^Q ^M
+math		^Q ^[ [ 1 0 9 ; 5 u
 math		^Q m
 msg		^[ H
 msg		^[ ^H
@@ -713,6 +715,7 @@ query		^[ ?
 record		^[ (
 retype		^]
 rtn		^M
+rtn		^[ [ 1 0 9 ; 5 u
 shell		^K Z
 shell		^K ^Z
 shell		^K z
@@ -960,6 +963,7 @@ mode,"overtype",rtn	.kI
 lindent		^K ,		Indent to left
 line		^Q I		Goto line no.
 line		^Q ^I
+line		^Q ^[ [ 1 0 5 ; 5 u
 line		^Q i
 ltarw		.kl		Go left
 ltarw		^S
@@ -1048,6 +1052,7 @@ shell4		.k4
 :inherit main
 abort		^C
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^X
 dnarw,eol	^[ O B
@@ -1117,11 +1122,13 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 rtn		^J
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^E
 uparwmenu	^[ [ A
@@ -1143,8 +1150,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1162,6 +1171,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace

--- a/rc/rjoerc.in
+++ b/rc/rjoerc.in
@@ -691,6 +691,7 @@ abort		^K q
 arg		^K \		Repeat next command
 explode		^K I		Show all windows or show only one window
 explode		^K ^I
+explode		^K ^[ [ 1 0 5 ; 5 u
 explode		^K i
 help		^K H		Help menu
 help		^K ^H
@@ -700,6 +701,7 @@ hprev		^[ ,		Previous help window
 maths		^[ m		Calculator
 maths		^[ M		Calculator
 maths		^[ ^M		Calculator
+maths		^[ ^[ [ 1 0 9 ; 5 u
 msg		^[ h		Display a message
 msg		^[ H		Display a message
 msg		^[ ^H		Display a message
@@ -722,6 +724,7 @@ query		^K ?		Macro query insert
 record		^K [		Record a macro
 retype		^R		Refresh screen
 rtn		^M		Return
+rtn		^[ [ 1 0 9 ; 5 u
  shell		^K Z		Shell escape
  shell		^K ^Z
  shell		^K z
@@ -821,6 +824,7 @@ tomarkk		^[ ^K		Go to end of marked block
 tomarkk		^[ K		Go to end of marked block
 txt		^[ i		Prompt for text and insert it
 txt		^[ ^I		Prompt for text and insert it
+txt		^[ ^[ [ 1 0 5 ; 5 u
 txt		^[ I		Prompt for text and insert it
 upslide		^[ w		Scroll up one line
 upslide		^[ ^W		Scroll up one line
@@ -876,6 +880,7 @@ blkdel		^K ^Y
 blkdel		^K y
 blkmove		^K M		Move marked block
 blkmove		^K ^M
+blkmove		^K ^[ [ 1 0 9 ; 5 u
 blkmove		^K m
  blksave		^K W		Save marked block
  blksave		^K ^W
@@ -998,6 +1003,7 @@ uparw		^[ [ A
 :prompt			Prompt windows
 :inherit main
 complete	^I
+complete	^[ [ 1 0 5 ; 5 u
 dnarw,eol	.kd		Go down
 dnarw,eol	^N
 dnarw,eol	^[ O B
@@ -1066,10 +1072,12 @@ rtarwmenu	^[ [ C
 rtarwmenu	^[ O C
 rtn		SP
 rtn		^I
+rtn		^[ [ 1 0 5 ; 5 u
 rtn		^K H
 rtn		^K h
 rtn		^K ^H
 tabmenu		^I
+tabmenu		^[ [ 1 0 5 ; 5 u
 uparwmenu	.ku
 uparwmenu	^P
 uparwmenu	^[ [ A
@@ -1091,8 +1099,10 @@ type		U+0 TO U+10FFFF
 ""		^C		Abort
 ""		^D		Eof
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace
 
 :vtshell		Input to ANSI shell windows
@@ -1110,6 +1120,8 @@ type		U+0 TO U+10FFFF
 ""		^D		Eof
 ""		^E		EOL for bash
 "\t"		^I		Tab
+"\t"		^[ [ 1 0 5 ; 5 u
 ""		^H		Backspace
 "\r"		^M		Return
+"\r"		^[ [ 1 0 9 ; 5 u
 ""		^?		Backspace


### PR DESCRIPTION
Add CSIu sequences for `^I` and `^M`, which are favored by the popular [Ghostty](https://ghostty.org/) terminal. See https://www.leonerd.org.uk/hacks/fixterms/

Fixes #36 
