### PR TITLE
Remap CSIu for ^I to tab when typing

### DIFF
--- a/rc/jmacsrc.in
+++ b/rc/jmacsrc.in
@@ -730,6 +730,9 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
+
 :main			Text editing window
 :inherit windows
 

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -844,6 +844,9 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
+
  Sample if/then/else macro
  if,"char==65",then,"it's an A",else,"it's not an a",endif	^[ q
 

--- a/rc/joerc.zh_TW.in
+++ b/rc/joerc.zh_TW.in
@@ -792,6 +792,9 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
+
  Sample if/then/else macro
  if,"char==65",then,"it's an A",else,"it's not an a",endif	^[ q
 

--- a/rc/jpicorc.in
+++ b/rc/jpicorc.in
@@ -749,6 +749,8 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
 
 :main			Text editing window
 :inherit windows

--- a/rc/jstarrc.in
+++ b/rc/jstarrc.in
@@ -738,6 +738,9 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
+
 :main			Text editing window
 :inherit windows
 

--- a/rc/rjoerc.in
+++ b/rc/rjoerc.in
@@ -748,6 +748,9 @@ defmiddledown	MIDDLEDOWN	Insert text
 xtmouse		^[ [ M		Introduces an xterm mouse event
 extmouse	^[ [ <		Introduces an extended xterm mouse event
 
+ CSIu for ^I
+"\t"		^[ [ 1 0 5 ; 5 u
+
 :main			Text editing window
 :inherit windows
 


### PR DESCRIPTION
Missing from #62, which handled all the command sequences but not *typing* a tab with `^I`