### PR TITLE
Only ASCII is safe to use in OSC 8 link text, so use `->` instead of `→`.

### DIFF
--- a/joe/bw.c
+++ b/joe/bw.c
@@ -410,7 +410,8 @@ static struct state_debug_data out_osc8(const struct state_debug_data *oldstate,
 				ttputs(";");
 				ttputs(state_names[newstate->name]);
 				if (newstate->recolor && newstate->recolor != newstate->name) {
-					ttputs("→");
+					/* ugh, only ASCII for OSC-8 pop-up text */
+					ttputs("->");
 					ttputs(state_names[newstate->recolor]);
 				}
 				ttputs("\x1B\\");


### PR DESCRIPTION
…`→`.

Turns out that terminals will render in whatever they think the character set is. `→` will appear as itself or three other characters or one other character (the first of the three) or the pop-up text will be missing.