### PR TITLE
Extended syntax support (flags etc.); improved handling of `#if 0` (chaining)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,6 +233,8 @@ AX_GCC_FUNC_ATTRIBUTE([fallthrough])
 AX_GCC_FUNC_ATTRIBUTE([malloc])
 AX_GCC_FUNC_ATTRIBUTE([malloc_args])
 AX_GCC_FUNC_ATTRIBUTE([alloc_size])
+AX_GCC_FUNC_ATTRIBUTE([nonnull])
+AX_GCC_FUNC_ATTRIBUTE([returns_nonnull])
 
 AC_CONFIG_FILES([Makefile joe/Makefile joe/util/Makefile rc/Makefile
 man/Makefile man/ru/Makefile syntax/Makefile po/Makefile colors/Makefile

--- a/joe/blocks.c
+++ b/joe/blocks.c
@@ -13,10 +13,15 @@
 
 #if SIZEOF_INT == 8
 #  define SHFT 3
+#  define INTFILL_CHAR 0x0101010101010101
 #elif SIZEOF_INT == 4
 #  define SHFT 2
+#  define INTFILL_CHAR 0x01010101
 #elif SIZEOF_INT == 2
 #  define SHFT 1
+#  define INTFILL_CHAR 0x0101
+#else
+#  error I do not know how to handle your strange integers
 #endif
 
 /* Set 'sz' 'int's beginning at 'd' to the value 'c' */
@@ -206,17 +211,7 @@ char *mset(char *dest, char c, ptrdiff_t sz)
 			d += z;
 			sz -= z;
 		}
-		msetI((int *)d,
-#if SIZEOF_INT >= 8
-		      (c << (BITS * 7)) + (c << (BITS * 6)) + (c << (BITS * 5)) + (c << (BITS * 4)) +
-#endif
-#if SIZEOF_INT >= 4
-		      (c << (BITS * 3)) + (c << (BITS * 2)) +
-#endif
-#if SIZEOF_INT >= 2
-		      (c << BITS) +
-#endif
-		      c, sz >> SHFT);
+		msetI((int *)d, ((int)c & 255) * INTFILL_CHAR, sz >> SHFT);
 		d += sz & ~(SIZEOF_INT - 1);
 		switch (sz & (SIZEOF_INT - 1)) {
 		case 7:		d[6] = c; FALLTHROUGH

--- a/joe/charmap.c
+++ b/joe/charmap.c
@@ -91,8 +91,8 @@ int from_utf8(struct charmap *map,const char *s)
 /* Aliases */
 
 static const struct {
-	const char *alias;
-	const char *builtin;
+	const char alias[12];
+	const char builtin[12];
 } alias_table[] = {
 	{ "c", "ascii" },
 	{ "posix", "ascii" },
@@ -129,7 +129,7 @@ static const struct {
 	{ "latin8", "iso-8859-14" },
 	{ "latin9", "iso-8859-15" },
 	{ "latin10", "iso-8859-16" },
-	{ 0, 0 }
+	{}
 };
 
 /* I took all the ISO-8859- ones, plus any ones referenced by a locale */
@@ -1368,7 +1368,7 @@ struct charmap *find_charmap(const char *name)
 		load_builtins();
 
 	/* Alias? */
-	for (y=0; alias_table[y].alias; ++y)
+	for (y=0; alias_table[y].alias[0]; ++y)
 		if (!map_name_cmp(alias_table[y].alias,name)) {
 			name = alias_table[y].builtin;
 			break;
@@ -1435,7 +1435,7 @@ char **get_encodings(void)
 
 	/* Aliases */
 
-	for (y=0; alias_table[y].alias; ++y) {
+	for (y=0; alias_table[y].alias[0]; ++y) {
 		r = vsncpy(NULL,0,sz(alias_table[y].alias));
 		encodings = vaadd(encodings, r);
 	}

--- a/joe/syntax.c
+++ b/joe/syntax.c
@@ -189,12 +189,23 @@ static HIGHLIGHT_STATE ansi_parse(P *line, HIGHLIGHT_STATE h_state)
 	return h_state;
 }
 
+static struct high_cmd *test_cmd(const int statebits, struct high_cmd *cmd)
+{
+	if (!cmd) return NULL;
+	/* NULL if a test fails */
+	if (cmd->state_test_all  && (statebits & cmd->state_test_all ) != cmd->state_test_all) return NULL;
+	if (cmd->state_test_any  && (statebits & cmd->state_test_any ) == 0) return NULL;
+	if (cmd->state_test_none && (statebits & cmd->state_test_none) != 0) return NULL;
+	return cmd;
+}
+
 HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state,struct charmap *charmap)
 {
 	struct high_frame *stack;
 	struct high_delim_frame *delim_stack;
 	struct high_state *h;
 			/* Current state */
+	int statebits;
 	int buf[SAVED_SIZE];		/* Name buffer (trunc after 23 characters) */
 	int lbuf[3*SAVED_SIZE];		/* Lower case version of name buffer */
 	int lsaved_s[3*SAVED_SIZE];	/* Lower case version of delimiter match buffer */
@@ -224,6 +235,7 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 
 	stack = h_state.stack;
 	delim_stack = h_state.delim_stack;
+	statebits = h_state.statebits;
 	h = (stack ? stack->syntax : syntax)->states[h_state.state];
 	buf_idx = 0;
 	attr = attr_buf;
@@ -240,7 +252,8 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 
 	/* Get next character */
 	while((c=pgetc(line))!=NO_MORE_DATA) {
-		struct high_cmd *cmd, *kw_cmd;
+		struct high_cmd *cmd = NULL;
+		struct high_cmd *kw_cmd;
 		int iters = -8; /* +8 extra iterations before cycle detect. */
 		ptrdiff_t x;
 
@@ -283,8 +296,13 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 				cmd = h->same_delim;
 			else {
 				cmd = (struct high_cmd *)rtree_lookup(&h->rtree, c);
-				if (!cmd)
-					cmd = h->dflt;
+				if (!cmd) {
+					for (int i = h->test_count - 1; i >= 0; --i)
+						if ((cmd = test_cmd(statebits, h->test_states[i])))
+							break;
+					if (!cmd)
+						cmd = h->dflt;
+				}
 			}
 
 			/* Lowerize strings for case-insensitive matching */
@@ -308,12 +326,16 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 				recolor_delimiter_or_keyword = 1;
 			}
 
+			/* Uodate state word */
+			statebits &= cmd->statekeep;
+			statebits ^= cmd->stateflip;
+
 			/* Determine new state */
 			if (cmd->call) {
 				/* Call */
 				struct high_frame **frame_ptr = stack ? &stack->child : &syntax->stack_base;
 				/* Search for an existing stack frame for this call */
-				while (*frame_ptr && !((*frame_ptr)->syntax == cmd->call && (*frame_ptr)->return_state == cmd->new_state))
+				while (*frame_ptr && !((*frame_ptr)->syntax == cmd->call && (*frame_ptr)->return_state == cmd->new_state && (*frame_ptr)->statebits == statebits))
 					frame_ptr = &(*frame_ptr)->sibling;
 				if (*frame_ptr)
 					stack = *frame_ptr;
@@ -324,6 +346,7 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 					frame->sibling = 0;
 					frame->syntax = cmd->call;
 					frame->return_state = cmd->new_state;
+					frame->statebits = statebits;
 					*frame_ptr = frame;
 					stack = frame;
 					++stack_count;
@@ -332,12 +355,15 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 			} else if (cmd->rtn) {
 				/* Return */
 				if (stack) {
+					if (!cmd->keep_statebits)
+						statebits = stack->statebits;
 					h = stack->return_state;
 					stack = stack->parent;
 				} else
 					/* Not in a subroutine, so ignore the return */
 					h = cmd->new_state;
 			} else if (cmd->reset) {
+				/* do NOT reset statebits here! */
 				h = syntax->states[0];
 			} else {
 				/* Normal edge */
@@ -470,6 +496,7 @@ HIGHLIGHT_STATE parse(struct high_syntax *syntax,P *line,HIGHLIGHT_STATE h_state
 	h_state.stack = stack;
 	h_state.delim_stack = delim_stack;
 	h_state.state = h->no;
+	h_state.statebits = statebits;
 	return h_state;
 }
 
@@ -512,6 +539,7 @@ static struct high_state *find_state(struct high_syntax *syntax,char *name)
 		syntax->states[syntax->nstates++]=state;
 		rtree_init(&state->rtree);
 		state->dflt = &syntax->default_cmd;
+		state->test_count = 0;
 		state->delim = 0;
 		state->same_delim = 0;
 		htadd(syntax->ht_states, state_names[state->name], state);
@@ -558,6 +586,9 @@ static void iz_cmd(struct high_cmd *cmd)
 	cmd->rtn = 0;
 	cmd->reset = 0;
 	cmd->call = 0;
+	cmd->state_test_all = cmd->state_test_any = cmd->state_test_none = 0;
+	cmd->statekeep = -1;
+	cmd->stateflip = 0;
 }
 
 static struct high_cmd *mkcmd(void)
@@ -653,6 +684,7 @@ void dump_syntax(BW *bw)
 			}
 #endif
 			joe_snprintf_2(buf, SIZEOF(buf), "     default -> %s %d\n",(s->dflt->new_state ? state_names[s->dflt->new_state->name] : "ERROR! Unknown state!"),(int)s->dflt->recolor);
+			// FIXME: print tests too
 			binss(bw->cursor, buf);
 			pnextl(bw->cursor);
 		}
@@ -727,7 +759,77 @@ struct high_syntax *load_syntax_subr(const char *name,char *subr,struct high_par
 
 /* Parse options */
 
-static int parse_options(struct high_syntax *syntax,struct high_cmd *cmd,JFILE *f,const char *p,int parsing_strings,char *name,int line)
+enum { USE_ALL = 1, USE_ANY = 2, USE_NONE = 4 }; /* bitmask */
+
+static int parse_flagbits(const char **p, const char *name, const int line, const struct high_cmd *cmd, int use, int dflt)
+{
+	int value = 0;
+	parse_ws(p, '#');
+	if (cmd && !parse_char(p, '~')) {
+		char buf[256];
+		parse_ws(p, '#');
+		if (parse_ident(p, buf, SIZEOF(buf)))
+			goto badflag;
+		if (!zcmp(buf, "all"))
+			return ~cmd->state_test_all;
+		else if (!zcmp(buf, "any"))
+			return ~cmd->state_test_any;
+		else if (!zcmp(buf, "none"))
+			return ~cmd->state_test_none;
+		else if (!zcmp(buf, "other")) {
+			value = 0;
+			if (use & USE_ALL)  value |= cmd->state_test_all;
+			if (use & USE_ANY)  value |= cmd->state_test_any;
+			if (use & USE_NONE) value |= cmd->state_test_none;
+			return ~value;
+		} else {
+			logerror_2(joe_gettext(_("%s %d: Unknown class\n")), name, line);
+			return 0;
+		}
+	} else if (!parse_char(p, '=')) {
+		/* integer mask */
+		parse_ws(p, '#');
+		if (parse_int(p, &value)) goto badflag;
+		return value;
+	} else if (!parse_char(p, '@')) {
+		/* list of bit positions */
+		for (;;) {
+			int v1 = 0, v2 = 0;
+			parse_ws(p, '#');
+			if (parse_int(p, &v1)) goto badflag;	/* expected int */
+			if (v1 < 0 || v1 > 31) goto bitrange;	/* range 0..31 */
+			value |= 1 << v1;
+			parse_ws(p, '#');
+			if (!parse_char(p, ',')) continue;	/* comma -> read next bit no. */
+			if (parse_char(p, '-')) break;		/* hyphen = range -> read other end's bit no. */
+			/* range (inclusive) */
+			parse_ws(p, '#');
+			if (parse_int(p, &v2)) goto badflag;	/* expected int */
+			if (v2 < 0 || v2 > 31) goto bitrange;	/* range 0..31 again */
+			if (v2 > v1)
+				while (v1 <= v2 && v1 < 32)
+					value |= 1 << v1++;
+			else
+				while (v2 <= v1 && v2 < 32)
+					value |= 1 << v2++;
+			parse_ws(p, '#');
+			if (parse_char(p, ',')) break;		/* comma -> read next bit no. */
+		}
+		return value;
+	} else if (dflt)
+		return dflt;
+
+  badflag:
+	logerror_2(joe_gettext(_("%s %d: Missing value for option\n")), name, line);
+	return 0;
+
+  bitrange:
+	logerror_3("%s %d: %s\n", name, line, joe_gettext(_("Value out of range")));
+	return 0;
+}
+
+
+static int parse_options(struct high_syntax *syntax,struct high_cmd *cmd,JFILE *f,const char *p,int parsing_strings,char *name,int line, int is_test_cmd)
 {
 	char buf[1024];
 	char bf[256];
@@ -780,9 +882,40 @@ static int parse_options(struct high_syntax *syntax,struct high_cmd *cmd,JFILE *
 				logerror_2(joe_gettext(_("%s %d: Missing value for option\n")),name,line);
 		} else if(!zcmp(bf,"return")) {
 			cmd->rtn = 1;
-		} else if(!zcmp(bf,"reset")) {
-			cmd->reset = 1;
-		} else if(!parsing_strings && (!zcmp(bf,"strings") || !zcmp(bf,"istrings"))) {
+		} else if(!zcmp(bf,"returnstate")) {
+			cmd->keep_statebits = cmd->rtn = 1;
+		} else if(!zcmp(bf,"sset")) {
+			int bits = parse_flagbits(&p, name, line, NULL, 0, 0);
+			cmd->statekeep &= ~bits;
+			cmd->stateflip |= bits;
+		} else if(!zcmp(bf,"sclear")) {
+			int bits = parse_flagbits(&p, name, line, NULL, 0, -1);
+			cmd->statekeep &= ~bits;
+			cmd->stateflip &= ~bits;
+		} else if(!zcmp(bf,"sflip")) {
+			int bits = parse_flagbits(&p, name, line, NULL, 0, -1);
+			cmd->statekeep |= bits;
+			cmd->stateflip |= bits;
+		} else if(!zcmp(bf,"sifall")) {
+			if (is_test_cmd)
+				cmd->state_test_all |= parse_flagbits(&p, name, line, cmd, USE_ANY | USE_NONE, 0);
+			else
+				logerror_3(joe_gettext(_("%s %d: '%s' found outside a test command\n")), name, line, bf);
+		} else if(is_test_cmd && !zcmp(bf,"sifany")) {
+			if (is_test_cmd)
+				cmd->state_test_any |= parse_flagbits(&p, name, line, cmd, USE_ALL | USE_NONE, 0);
+			else
+				logerror_3(joe_gettext(_("%s %d: '%s' found outside a test command\n")), name, line, bf);
+		} else if(is_test_cmd && !zcmp(bf,"sifnone")) {
+			if (is_test_cmd)
+				cmd->state_test_none |= parse_flagbits(&p, name, line, cmd, USE_ALL | USE_ANY, 0);
+			else
+				logerror_3(joe_gettext(_("%s %d: '%s' found outside a test command\n")), name, line, bf);
+		} else if(!zcmp(bf,"strings") || !zcmp(bf,"istrings")) {
+			if (parsing_strings) {
+				logerror_3(joe_gettext(_("%s %d: '%s' found but already in strings mode\n")), name, line, bf);
+				continue;
+			}
 			if (bf[0]=='i')
 				cmd->ignore = 1;
 			while(jfgets(buf,sizeof(buf),f)) {
@@ -809,7 +942,7 @@ static int parse_options(struct high_syntax *syntax,struct high_cmd *cmd,JFILE *
 									cmd->keywords = Zhtmk(64);
 								Zhtadd(cmd->keywords, (cmd->ignore ? Zdup(lkwbuf) : Zdup(kwbuf)), kw_cmd);
 							}
-							line = parse_options(syntax,kw_cmd,f,p,1,name,line);
+							line = parse_options(syntax,kw_cmd,f,p,1,name,line,is_test_cmd);
 						} else
 							logerror_2(joe_gettext(_("%s %d: Missing state name\n")),name,line);
 					} else
@@ -826,7 +959,17 @@ static int parse_options(struct high_syntax *syntax,struct high_cmd *cmd,JFILE *
 			cmd->recolor_mark = 1;
 		} else
 			logerror_2(joe_gettext(_("%s %d: Unknown option\n")),name,line);
+
+	if (is_test_cmd && cmd->state_test_all == 0 && cmd->state_test_any == 0 && cmd->state_test_none == 0)
+		logerror_2(joe_gettext(_("%s %d: bit-test has no valid bit tests\n")), name, line);
+
 	return line;
+}
+
+static void check_state_bugs(const struct high_state *state, const struct high_syntax *syntax, const char *name, int line)
+{
+	if (state->test_count && state->dflt == &syntax->default_cmd)
+		logerror_2(joe_gettext(_("%s %d: state has bit tests but no default command\n")), name, line);
 }
 
 struct ifstack {
@@ -850,6 +993,7 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 	struct ifstack *stack=0;
 	struct high_state *state=0;	/* Current state */
 	struct high_state *first=0;	/* First state */
+	int state_start_line = 0;
 	int line = 0;
 	int this_one = 0;
 	int inside_subr = 0;
@@ -934,7 +1078,10 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 			/* Ignore this line because it's not the code we want */
 		} else if(!parse_char(&p, ':')) {
 			if(!parse_ident(&p, bf, SIZEOF(bf))) {
+				if (state)
+					check_state_bugs(state, syntax, fullpath, state_start_line);
 
+				state_start_line = line;
 				state = find_state(syntax,bf);
 
 				if (!first)
@@ -971,11 +1118,19 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 			c = parse_ws(&p,'#');
 
 			if (!c) {
-			} else if (c=='"' || c=='*' || c=='&' || c =='%') {
+			} else if (c=='"' || c=='*' || c == '~' || c=='&' || c =='%') {
 				if (state) {
 					struct high_cmd *cmd = mkcmd();
+					int/*bool*/ testcmd = 0;
 					if(!parse_field(&p, "*")) {
 						state->dflt = cmd;
+					} else if(!parse_field(&p, "~")) {
+						/* allocate 8 at a time, extend by 8 at need */
+						if (state->test_count % 8 == 0)
+							state->test_states = state->test_count ? joe_realloc(state->test_states, (unsigned int)(state->test_count + 8) * sizeof(*state->test_states)) : joe_calloc(8, sizeof(*state->test_states));
+						/* store, increment count */
+						state->test_states[state->test_count++] = cmd;
+						testcmd = 1;
 					} else if(!parse_field(&p, "&")) {
 						state->delim = cmd;
 					} else if(!parse_field(&p, "%")) {
@@ -998,7 +1153,7 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 					parse_ws(&p,'#');
 					if(!parse_ident(&p,bf,SIZEOF(bf))) {
 						cmd->new_state = find_state(syntax,bf);
-						line = parse_options(syntax,cmd,f,p,0,fullpath,line);
+						line = parse_options(syntax,cmd,f,p,0,fullpath,line,testcmd);
 					} else
 						logerror_2(joe_gettext(_("%s %d: Missing jump\n")),fullpath,line);
 				} else
@@ -1014,6 +1169,8 @@ static struct high_state *load_dfa(struct high_syntax *syntax)
 		logerror_2(joe_gettext(_("%s %d: ifdef with no matching endif\n")),fullpath,st->line);
 		joe_free(st);
 	}
+	if (state)
+		check_state_bugs(state, syntax, fullpath, state_start_line);
 
 	jfclose(f);
 

--- a/joe/syntax.c
+++ b/joe/syntax.c
@@ -587,6 +587,7 @@ static void iz_cmd(struct high_cmd *cmd)
 	cmd->reset = 0;
 	cmd->call = 0;
 	cmd->state_test_all = cmd->state_test_any = cmd->state_test_none = 0;
+	cmd->keep_statebits = false;
 	cmd->statekeep = -1;
 	cmd->stateflip = 0;
 }

--- a/joe/syntax.h
+++ b/joe/syntax.h
@@ -14,12 +14,17 @@ struct high_state {
 	ptrdiff_t no;			/* State number */
 	int name;			/* Highlight state name (index into state_names) */
 	int color;			/* Color for this state */
+	int statebits;			/* For use in the state machine */
+
+	int test_count;			/* number of state word tests */
+	struct high_cmd *dflt;		/* Defaults for no match (if only one) */
+	struct high_cmd **test_states;	/* For state word tests */
+	struct high_cmd *same_delim;	/* Same delimiter */
+	struct high_cmd *delim;		/* Matching delimiter */
+
 	struct color_def *colorp;	/* Mapped color definition */
 
 	struct Rtree rtree;		/* Character map (character ->struct high_cmd *) */
-	struct high_cmd *dflt;		/* Default for no match */
-	struct high_cmd *same_delim;	/* Same delimiter */
-	struct high_cmd *delim;		/* Matching delimiter */
 };
 
 /* Parameter list */
@@ -46,7 +51,14 @@ struct high_cmd {
 	bool stop_mark;			/* Set to end marked area excluding this char */
 	bool recolor_mark;		/* Set to recolor marked area with new state */
 	bool rtn;			/* Set to return */
+	bool keep_statebits;		/* Set to preserve statebits if returning */
 	bool reset;			/* Set to reset the call stack */
+
+	int stateflip, statekeep;	/* Mask words for altering statebits */
+	int state_test_all;		/* statebits test words, used if non-zero, fail match if false */
+	int state_test_any;
+	int state_test_none;
+
 	ptrdiff_t recolor;		/* No. chars to recolor if <0. */
 	struct high_state *new_state;	/* The new state */
 	ZHASH *keywords;		/* Hash table of keywords */
@@ -62,6 +74,7 @@ struct high_frame {
 	struct high_frame *sibling;		/* Caller's next callee's frame */
 	struct high_syntax *syntax;		/* Current syntax subroutine */
 	struct high_state *return_state;	/* Return state in the caller's subroutine */
+	int statebits;				/* Saved data */
 };
 
 /* delimiter stack frame */
@@ -105,10 +118,13 @@ struct state_debug_data {
 extern attr_data *attr_buf;
 extern struct state_debug_data *syndebug_buf;
 
-#define clear_state(s) (((s)->saved_s = 0), ((s)->state = 0), ((s)->stack = 0), ((s)->delim_stack = 0))
-#define invalidate_state(s) (((s)->state = -1), ((s)->saved_s = 0), ((s)->stack = 0), ((s)->delim_stack = 0))
+#define clear_state(s) (((s)->saved_s = 0), ((s)->state = 0), ((s)->stack = 0), ((s)->delim_stack = 0), ((s)->statebits = 0))
+#define invalidate_state(s) (((s)->state = -1), ((s)->saved_s = 0), ((s)->stack = 0), ((s)->delim_stack = 0), ((s)->statebits = 0))
 #define move_state(to,from) (*(to)= *(from))
+/*
 #define eq_state(x,y) ((x)->state == (y)->state && (x)->stack == (y)->stack && (x)->delim_stack == (y)->delim_stack && (x)->saved_s == (y)->saved_s)
+*/
+#define eq_state(x,y) (0)
 
 extern struct high_syntax *syntax_list;
 

--- a/joe/types.h
+++ b/joe/types.h
@@ -342,6 +342,7 @@ struct highlight_state {
 	struct high_delim_frame *delim_stack; /* Pointer to the previously pushed delimiter buffer */
 	const int *saved_s; /* Interned Z-string for saved delimiter */
 	ptrdiff_t state; /* Current state in the current subroutine */
+	int statebits;
 };
 
 /* It's a good idea to optimize the size of struct highlight_state since there are N of

--- a/joe/types.h
+++ b/joe/types.h
@@ -33,6 +33,19 @@
 #define ATTR_ALLOC_SIZE(arg)
 #endif
 
+/* Also doubled parentheses */
+#ifdef HAVE_FUNC_ATTRIBUTE_NONNULL
+#define NONNULL(arg) __attribute__((nonnull arg))
+#else
+#define NONNULL(arg)
+#endif
+
+#ifdef HAVE_FUNC_ATTRIBUTE_RETURNS_NONNULL
+#define RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#define RETURNS_NONNULL
+#endif
+
 #define TO_DIFF_OK(a) ((ptrdiff_t)(a)) /* Means it's OK that we are converting off_t to ptrdiff_t in this case */
 #define TO_CHAR_OK(a) ((char)(a)) /* Means it's OK that we are converting int to char */
 #define SIZEOF(a) ((ptrdiff_t)sizeof(a)) /* Signed version of sizeof() */

--- a/joe/usearch.c
+++ b/joe/usearch.c
@@ -407,7 +407,7 @@ static SRCH *setmark(SRCH *srch)
 	return srch;
 }
 
-SRCH *mksrch(char *pattern, char *replacement, int ignore, int backwards, int repeat, int replace, int rest, int all, int regex)
+SRCH *mksrch(char *pattern, char *replacement, int ignore, int backwards, int repeat, int replace, int rest, enum searches all, int regex)
 {
 	SRCH *srch = (SRCH *) joe_malloc(SIZEOF(SRCH));
 	int x;
@@ -727,9 +727,9 @@ static int set_options(W *w, char *s, void *obj, int *notify)
 	while (*t) {
 		int c = fwrd_c(locale_map, &t, NULL);
 		if (yncheck(all_key, c))
-			srch->all = 1;
+			srch->all = SEARCH_ALL;
 		else if (yncheck(list_key, c))
-			srch->all = 2;
+			srch->all = SEARCH_ERROR_LIST;
 		else if (yncheck(replace_key, c))
 			srch->replace = 1;
 		else if (yncheck(backwards_key, c))
@@ -869,7 +869,7 @@ int dofirst(BW *bw, int back, int repl, char *hint)
 			prgetc(bw->cursor);
 		return urtn(bw->parent, -1);
 	}
-	srch = mksrch(NULL, NULL, 0, back, -1, repl, 0, 0, std_regex);
+	srch = mksrch(NULL, NULL, 0, back, -1, repl, 0, SEARCH_ONE, std_regex);
 	srch->addr = bw->cursor->byte;
 	srch->wrap_p = pdup(bw->cursor, "dofirst");
 	srch->wrap_p->owner = &srch->wrap_p;
@@ -1140,9 +1140,9 @@ static int fnext(BW *bw, SRCH *srch)
 		sta = searchb(bw, srch, bw->cursor);
 	else
 		sta = searchf(bw, srch, bw->cursor);
-	if (!sta && srch->all) {
+	if (!sta && srch->all != SEARCH_ONE) {
 		B *b;
-		if (srch->all == 2)
+		if (srch->all == SEARCH_ERROR_LIST)
 			b = beafter(srch->current);
 		else {
 			berror = 0;
@@ -1378,6 +1378,6 @@ void load_srch(FILE *f)
 			parse_int(&p,&block_restrict);
 		}
 	}
-	globalsrch = mksrch(pattern,replacement,ignore,backwards,-1,replace,0,0,regex);
+	globalsrch = mksrch(pattern,replacement,ignore,backwards,-1,replace,0,SEARCH_ONE,regex);
 	globalsrch->block_restrict = block_restrict;
 }

--- a/joe/usearch.h
+++ b/joe/usearch.h
@@ -17,6 +17,12 @@ struct srchrec {
 
 #define NMATCHES 26
 
+enum searches {
+	SEARCH_ONE,
+	SEARCH_ALL,
+	SEARCH_ERROR_LIST,
+};
+
 struct search {
 	char	*pattern;	/* Search pattern */
 	struct regcomp *comp;	/* Compiled pattern */
@@ -40,14 +46,14 @@ struct search {
 	off_t	addr;		/* Where to place cursor after failed restruct_to_block() test */
 	off_t	last_repl;	/* Address of last replacement (prevents infinite loops) */
 	int	block_restrict;	/* Search restricted to marked block */
-	int	all;		/* Set to continue in other windows */
+	enum searches all;	/* Set to continue in other windows */
 	B	*first;		/* Starting buffer */
 	B	*current;	/* Current buffer */
 };
 
 extern int std_regex; /* Standard regex format by default */
 
-SRCH *mksrch(char *pattern, char *replacement, int ignore, int backwards, int repeat, int replace, int rest, int all, int regex);
+SRCH *mksrch(char *pattern, char *replacement, int ignore, int backwards, int repeat, int replace, int rest, enum searches all, int regex);
 void rmsrch(SRCH *srch);
 
 void setpat(SRCH *srch, char *pattern);

--- a/joe/utag.c
+++ b/joe/utag.c
@@ -92,7 +92,7 @@ static int dotagjump(BW *bw, int flag)
 	} else {
 		if (flag)
 			smode = 2;
-		return dopfnext(bw, mksrch(vsncpy(NULL, 0, sv(srch)), NULL, 0, 0, -1, 0, 0, 0, 0), NULL);
+		return dopfnext(bw, mksrch(vsncpy(NULL, 0, sv(srch)), NULL, 0, 0, -1, 0, 0, SEARCH_ONE, 0), NULL);
 	}
 }
 
@@ -140,7 +140,7 @@ static int dotagmenu(MENU *m, ptrdiff_t x, void *obj, int k)
 		return 0;
 	} else {
 		smode = 2;
-		return dopfnext(bw, mksrch(vsncpy(NULL, 0, sv(srch)), NULL, 0, 0, -1, 0, 0, 0, 0), NULL);
+		return dopfnext(bw, mksrch(vsncpy(NULL, 0, sv(srch)), NULL, 0, 0, -1, 0, 0, SEARCH_ONE, 0), NULL);
 	}
 }
 

--- a/syntax/c.jsf
+++ b/syntax/c.jsf
@@ -30,16 +30,30 @@
 
 # Within a state, define transitions (jumps) to other states.  Each
 # jump has the form: <character-list> <target-state> [<option>s]
-
-# There are three ways to specify <character-list>s: * for any character not
-# otherwise specified, % or & to match the character in the delimiter match
-# buffer (use % for an exact match, or & for an opposite match- for example,
-# < matches >) or a literal list of characters within quotes (ranges and
-# escape sequences allowed).  When the next character matches any in the
-# list, a jump to the target-state is taken and the character is eaten (we
-# advance to the next character of the file to be colored).
 #
-# The * transition should be the first transition specified in the state.
+# There are three special ways to specify <character-list>s:
+#   *      for any character not otherwise specified
+#   ~      for any character not otherwise specified, but with match rules
+#          (several may be present; these are evaluated in reverse order)
+#   % or & to match the character in the delimiter match buffer
+#          - use % for an exact match
+#          - use & for an opposite match, e.g. < matches >
+#
+# The ordinary way is to put the characters to be matched within quotation
+# marks, e.g. "a" or "abcd".  Ranges are allowed, e.g.  "a-d" (same as
+# "abcd"), as are escape sequences, e.g.  "\n" for the line-feed character.
+# When the next character matches any in the list, a jump to the
+# target-state is taken and the character is eaten (we advance to the next
+# character of the file to be colored).
+#
+# The * transition should be the first transition specified in the state and
+# should normally be present.  It is expected to be present if any ~
+# transitions are specified in the same state.
+#
+# Later transitions will replace earlier transitions which are of the same
+# type (*; % or &; character lists, for the same character).  However,
+# multiple ~ transitions may be listed; these are evaluated in reverse
+# order.
 #
 # There are several options:
 #   noeat     	do not eat the character, instead feed it to the next state
@@ -54,6 +68,42 @@
 #   mark	Mark beginning of a region with current position.
 #
 #   markend	Mark end of region.
+#
+#   sset...	Set state bit(s). This does not clear any bits.
+#   sclear...	Clear state bit(s).
+#   sflip...	Toggle state bit(s).
+#   sifall...	Match rule: all tested state bits must be set.
+#   sifany...	Match rule: at least one tested state bit must be set.
+#   sifnone...	Match rule: all tested state bits must be clear.
+#
+#		These commands take a 32-bit mask word or a comma-separated
+#		list of bit numbers. E.g. these all set the same four bits:
+#		     sset=0xF000
+#		     set@12,13,14,15
+#                    sset@12-15
+#
+#               sclear & sflip, without a parameter, act as sclear=-1 and
+#               sflip=-1 respectively.
+#
+#		Additionally, the match rules take "~all", "~any", "~none"
+#		or "~other".  The first three are evaluated to the inverse
+#		of the already-parsed value (for this rule) of the
+#		corresponding stest command; "~other" uses the common bits
+#		from the other two stest commands.
+#
+#		So to test that the flags word is exactly 0xF000:
+#		     sifall=0xF000 sifnone=0xFFFF0FFF
+#		     sifall=0xF000 sifnone~all
+#
+#		Or all of bits 12-15, any of bits 0-3 but no others:
+#		     sifall=0xF000 sifany=15  sifnone=0xFFFF0FF0
+#		     sifall=0xF000 sifany=0xF sifnone~other
+#
+#		NOTE: you should normally use the match rules only on ~
+#		transitions because for character matching, only the last
+#		transition defined in the state for any given character can
+#		match tha character.  If it fails due to a failed match
+#		rule, the default * transition will be chosen instead.
 #
 #   recolormark Recolor all of the characters in the marked region with
 #               the color of the target-state.  If markend is not given,
@@ -105,7 +155,7 @@
 #
 #   (all of the options above are allowed except "strings", "istrings" and "noeat".  noeat is
 #    always implied after a matched string).
-#
+
 # Weirdness: only states have colors, not transitions.  This means that you
 # sometimes have to make dummy states with '* next-state noeat' just to get
 # a color specification.
@@ -127,6 +177,11 @@
 #
 # The subroutine itself returns to the caller like this:
 #       "\""	whatever  return
+#
+# The state bits word is saved when calling a subroutine and is normally
+# restored on return.  It can be returned by using 'returnstate' instead of
+# 'return':
+#	"\""	whatever  returnstate
 #
 # If we're in a subroutine, the return is made.  Otherwise the jump
 # to 'whatever' is made.

--- a/syntax/c.jsf
+++ b/syntax/c.jsf
@@ -262,14 +262,26 @@
 =Control
 
 =IfZero		+Comment
+=IfOne		+Bad
 
-:reset Idle
+:init Idle
+	*		init		noeat call=.main() sclear
+
+.subr main
+:init Idle
+	*		restart		noeat sclear@0,1
+
+:restart Idle
 	*		first		noeat
-	" \t"		reset
+	" \t"		restart
 
 :first Idle
 	*		idle		noeat
-	"#"		pre		mark
+	"#"		pre_ret		mark
+
+:pre_ret Preproc
+	*		pre		noeat
+	~		NULL		noeat return sifall@2
 
 :pre Preproc
 	*		preproc		noeat
@@ -296,131 +308,32 @@ done
 :precond Precond
 	*		preproc		noeat
 
-# handle top-level "#if 0" & "#elif 0"
 :preifzero Preproc
 	*		preproc		noeat
 	" \t"		preifzero
-	"0"		preproc		call=.ifzero()
-
-# handle "#if 0" & "#elif 0", accounting for nested #if* blocks
-# FIXME: check what directly follows the '0'?
-.subr ifzero
-:ifzero IfZero
-	*		ifzero
-	"\n"		ifzero_maybe_pre
-
-:ifzero_maybe_pre IfZero
-	*		ifzero		noeat
-	" \t"		ifzero_maybe_pre
-	"#"		ifzero_pre	mark
-
-:ifzero_pre IfZero
-	*		ifzero		noeat
-	" \t"		ifzero_pre
-	"i"		ifzero_preif	noeat buffer
-	"e"		ifzero_preend	noeat buffer
-
-:ifzero_preif IfZero
-	*		ifzero		noeat strings
-	"if"		ifzero_prenest
-	"ifdef"		ifzero_prenest
-	"ifndef"	ifzero_prenest
-done
-	"a-z"		ifzero_preif
-
-# recursion on nested #if* (but not #elif*)
-:ifzero_prenest IfZero
-	*		ifzero		noeat call=.ifzero(nested)
-
-:ifzero_preend IfZero
-.ifdef nested # only return on #endif
-	*		ifzero		noeat strings
-	"endif"		ifzero_predone
-	"else"		ifzero_preelse
-	"elif"		ifzero_preelse
-	"elifdef"	ifzero_preelse
-	"elifndef"	ifzero_preelse
-done
-.else # top-level, so return on #else* or #endif, but check for #elif 0
-	*		ifzero		noeat strings
-	"endif"		ifzero_predone
-	"else"		ifzero_predone
-	"elif"		ifzero_preifzero	markend recolormark
-	"elifdef"	ifzero_predone
-	"elifndef"	ifzero_predone
-done
-.endif
-	"a-z"		ifzero_preend
-
-# handle #elif 0
-:ifzero_preifzero Preproc
-	*		ifzero_predone	noeat
-	" \t"		ifzero_preifzero
-	"0"		ifzero
-
-# nested #else*; ignore it
-:ifzero_preelse IfZero
-	*		ifzero		noeat
-
-# any #endif or a top-level #else*
-:ifzero_predone Preproc
-	*		NULL		noeat markend recolormark return
-.end
-
-.subr inc_file
-:preinc Preproc
-	*		preinc
-	" \t"		preinc_ws
-	"\n"		NULL		noeat return
-
-:preinc_ws Preproc
-	*		preinc_trail	noeat recolor=-1
-	"\c"		preinc_ident	recolor=-1 # e.g. #embed __FILE__
-	" \t"		preinc_ws
-	"\""		preinc_local	recolor=-1
-	"<"		preinc_system	recolor=-1
-	"\n"		NULL		noeat return
-
-:preinc_local IncLocal string
-	*		preinc_local
-	"\""		preinc_trail
-	"\n"		NULL		noeat return
-
-:preinc_system IncSystem string
-	*		preinc_system
-	">"		preinc_trail
-	"\n"		NULL		noeat return
-
-:preinc_ident	Idle
-	*		preinc_trail	noeat
-	"\c"		preinc_ident
-
-:preinc_trail	Idle
-	*		NULL		noeat return
-	" \t"		preinc_trail
-	"\n"		NULL		noeat return
-.end
+	"0"		preproc		call=.ifzero(-one)
+	"1"		preproc		call=.ifzero(one)
 
 :preinc_end	Bad
 	*		preinc_end
 	"\\"		preinc_end_cont
 	"/"		preinc_end	call=.slash()
-	"\n"		NULL		noeat return
+	"\n"		restart		noeat
 
 :preinc_end_cont Bad
 	*		preinc_end
 
 :preembed_params	Idle
-	*		idle	noeat
+	*		restart		noeat call=.ccode()
 
 :prebad	Bad
 	*		prebad
-	"\n"		reset
+	"\n"		restart
 
 :predef Preproc
 	*		predef
 	" \t"		predef_ws
-	"\n"		reset
+	"\n"		restart
 
 :predef_ws Preproc
 	*		prebad		recolor=-1
@@ -433,7 +346,7 @@ done
 
 :preproc Preproc
 	*		preproc
-	"\n"		reset
+	"\n"		restart
 	"\\"		preproc_cont
 	"/"		preproc		call=.slash()
 
@@ -445,7 +358,7 @@ done
 
 :idle Idle
 	*		idle
-	"\n"		reset
+	"\n"		restart
 	"/"		idle		call=.slash()
 	"0"		first_digit	recolor=-1
 	"1-9"		decimal		recolor=-1
@@ -465,28 +378,6 @@ done
 
 :control Control
 	*	idle	noeat
-
-.subr slash
-:slash Comment comment
-	*		NULL		noeat recolor=-2 return	# Not sure about this
-	"*"		comment		recolor=-2
-	"/"		line_comment	recolor=-2
-
-:comment Comment comment
-	*		comment
-	"BFHNTX"	comment		noeat call=comment_todo.comment_todo()
-	"*"		maybe_end_comment
-
-:maybe_end_comment Comment comment
-	*		comment
-	"/"		NULL		return
-	"*"		maybe_end_comment
-
-:line_comment Comment comment
-	*		line_comment
-	"BFHNTX"	line_comment	noeat call=comment_todo.comment_todo()
-	"\n"		NULL		noeat return
-.end
 
 :first_digit Number
 	*		idle	noeat
@@ -560,13 +451,13 @@ done
 :string_control StringEscape string
 	*		string
 	"\""		string noeat
-	"\n"		reset
+	"\n"		restart
 	"\\"		string_escape	recolor=-1
 	"0-9.\-+ #hjILtz$"	string_control
 
 :char Character string
 	*		char
-	"\n"		reset
+	"\n"		restart
 	"'"		idle
 	"\\"		char_escape	recolor=-1
 
@@ -730,3 +621,317 @@ done
 
 :struct Structure
 	*	idle	noeat
+.end
+
+.subr eat_if01_line
+:eat Bad
+	*	eat
+	"/"	eat	call=.slash()
+	"\\"	eat_cont
+	"\n"	NULL	return noeat
+:eat_cont Bad
+	*	eat
+.end
+
+.subr eat_if_line
+:eat Preproc
+	*	eat
+	"/"	eat	call=.slash()
+	"\\"	eat_cont
+	"\n"	NULL	return noeat
+:eat_cont Bad
+	*	eat
+.end
+
+.subr eat_ifzero_line
+:eat IfZero
+	*	eat
+	"\\"	eat_cont
+	"\n"	NULL	return noeat
+:eat_cont Bad
+	*	eat
+.end
+
+# handle "#if 0" & "#elif 0", accounting for nested #if* blocks
+# flags word:
+#	b0 = seen #if 0, #elif 0 or a corresponding #else
+#	b1 = seen #if 1, #elif 1 or a corresponding #else
+#	b2 = exit .main for preprocessor handling
+
+.subr ifzero
+.ifdef one
+:initial IfZero
+	*		ifone		noeat sclear
+.else
+:initial IfZero
+	*		ifzero		noeat sclear
+.endif
+
+:ifzero IfZero
+	*		ifzero_main	noeat call=.eat_if01_line() sset@0
+
+:ifzero_main IfZero
+	*		ifzero_main
+	"\\"		ifzero_eatesc
+	"\n"		ifzero_maybe_pre
+
+:ifzero_eatesc IfZero
+	*		ifzero_main
+
+:ifzero_maybe_pre Idle
+	*		ifzero_main	noeat
+	" \t"		ifzero_maybe_pre
+	"#"		ifzero_pre	mark recolor=-1
+
+:ifzero_pre IfZero
+	*		ifzero_main	noeat
+	" \t"		ifzero_pre
+	"i"		ifzero_preif	noeat buffer
+	"e"		ifzero_preend	noeat buffer
+
+:ifzero_preif IfZero
+	*		ifzero_main	noeat strings
+	"if"		ifzero_prenest
+	"ifdef"		ifzero_prenest
+	"ifndef"	ifzero_prenest
+done
+	"a-z"		ifzero_preif
+
+# recursion on nested #if* (but not #elif*)
+:ifzero_prenest IfZero
+	*		ifzero		noeat call=.ifignored
+
+:ifzero_preend IfZero
+# only return on #endif, but check for #elif
+	*		ifzero_main	noeat strings
+	"endif"		ifzero_predone
+	"else"		ifzero_one		recolormark
+	"elif"		ifzero_preifzero	recolormark
+	"elifdef"	ifzero_preelse		recolormark call=.eat_if_line()
+	"elifndef"	ifzero_preelse		recolormark call=.eat_if_line()
+done
+	"a-z"		ifzero_preend
+
+# handle #elif [01]
+:ifzero_preifzero Preproc
+	*		ifzero_preelse	noeat call=.eat_if_line()
+	" \t"		ifzero_preifzero
+	"0"		ifzero
+	"1"		ifzero_one
+
+# #else, #elifdef, #elif [not 0 or 1] etc.
+:ifzero_preelse Preproc
+	*		ifzero		noeat
+	~		ifsomething	noeat call=.eat_if_line() sifnone@1
+
+:ifzero_predone Preproc
+	*		NULL		noeat markend recolormark return
+
+:ifzero_one Preproc
+	*		ifzero		noeat
+	~		ifone		noeat sifnone@1
+
+:ifsomething Preproc
+	*		ifzero		noeat
+	~		ifone_main	noeat sifnone@1
+
+:ifone IfOne
+	*		ifone_main	noeat call=.eat_if01_line() sset@1
+
+:ifone_main IfOne
+	*		i1pre		noeat call=.main() sset@2
+
+:ifone_zero Preproc
+	*		ifzero_preelse	noeat call=.eat_if_line()
+	" \t"		ifone_zero
+	"0"		ifzero		call=.eat_if01_line()
+	"1"		ifzero_one	call=.eat_if01_line()
+
+:ifone_preelse Preproc
+	*		ifzero		noeat
+
+:ifone_predone Preproc
+	*		NULL		noeat markend recolormark return
+
+:ifone_zero Preproc
+	*		ifzero		noeat
+
+:i1pre Preproc
+	*		i1preproc		noeat
+	" \t"		i1pre
+	"a-z"		i1preident		recolor=-1 buffer
+
+# More or less duplicated from code above (:preindent to :idle).
+# A few differences in where things lead, though.
+# TODO: find a good way to deduplicate this
+
+:i1preident Preproc
+	*		i1preproc		noeat markend recolormark strings
+	"define"	i1predef		markend recolormark
+	"include"	i1preinc_end		markend recolormark call=.inc_file()
+	"embed"		i1preembed_params	markend recolormark call=.inc_file()
+	"if"		i1preifzero		markend recolormark
+	"ifdef"		i1precond		markend recolormark
+	"ifndef"	i1precond		markend recolormark
+	"else"		ifone_preelse		markend recolormark
+	"elif"		i1zero			markend recolormark
+	"endif"		ifone_predone		markend recolormark
+	"undef"		i1predef		markend recolormark
+	"elifdef"	ifone_preelse		markend recolormark call=.eat_if_line() # C++23
+	"elifndef"	ifone_preelse		markend recolormark call=.eat_if_line() # C++23
+done
+	"a-z"		i1preident
+
+:i1precond Precond
+	*		i1preproc		noeat
+
+:i1preifzero Preproc
+	*		i1preproc		noeat
+	" \t"		i1preifzero
+	"0"		i1preproc		call=.ifzero(-one)
+	"1"		i1preproc		call=.ifzero(one)
+
+:i1zero Preproc #Debug
+	*		ifzero_preelse	noeat call=.eat_if_line()
+	" \t"		i1zero
+	"0"		ifzero		call=.eat_if01_line()
+	"1"		ifzero_one	call=.eat_if01_line()
+
+:i1preinc_end	Bad
+	*		i1preinc_end
+	"\\"		i1preinc_end_cont
+	"/"		i1preinc_end		call=.slash()
+	"\n"		ifone_main		noeat
+
+:i1preinc_end_cont Bad
+	*		i1preinc_end
+
+:i1preembed_params	Idle
+	*		ifone_main		noeat
+
+:i1prebad	Bad
+	*		i1prebad
+	"\n"		ifone_main
+
+:i1predef Preproc
+	*		i1predef
+	" \t"		i1predef_ws
+	"\n"		ifone_main
+
+:i1predef_ws Preproc
+	*		i1prebad		recolor=-1
+	" \t"		i1predef_ws
+	"\c"		i1predef_ident		recolor=-1
+
+:i1predef_ident Define
+	*		idle			noeat
+	"\c"		i1predef_ident
+
+:i1preproc Preproc
+	*		i1preproc
+	"\n"		ifone_main
+	"\\"		i1preproc_cont
+	"/"		i1preproc		call=.slash()
+
+:i1preproc_cont Preproc
+	*		i1preproc_cont
+	"\n"		i1preproc
+.end
+
+.subr ifignored
+:ifignored IfZero
+	*		ifignored_main		noeat call=.eat_ifzero_line()
+
+:ifignored_main IfZero
+	*		ifignored_main
+	"\n"		ifignored_maybe_pre
+
+:ifignored_maybe_pre IfZero
+	*		ifignored_main		noeat
+	" \t"		ifignored_maybe_pre
+	"#"		ifignored_pre		mark
+
+:ifignored_pre IfZero
+	*		ifignored_main		noeat
+	" \t"		ifignored_pre
+	"i"		ifignored_preif		noeat buffer
+	"e"		ifignored_preend	noeat buffer
+
+:ifignored_preif IfZero
+	*		ifignored_main		noeat strings
+	"if"		ifignored_prenest
+	"ifdef"		ifignored_prenest
+	"ifndef"	ifignored_prenest
+done
+	"a-z"		ifignored_preif
+
+# recursion on nested #if* (but not #elif*)
+:ifignored_prenest IfZero
+	*		ifignored		noeat call=.ifignored()
+
+:ifignored_preend IfZero
+	*		ifignored_main		noeat strings
+	"endif"		ifignored_predone	call=.eat_ifzero_line()
+done
+	"a-z"		ifignored_preend
+
+# any #endif or a top-level #else*
+:ifignored_predone Preproc
+	*		NULL		noeat markend recolormark return
+.end
+
+.subr inc_file
+:preinc Preproc
+	*		preinc
+	" \t"		preinc_ws
+	"\n"		NULL		noeat return
+
+:preinc_ws Preproc
+	*		preinc_trail	noeat recolor=-1
+	"\c"		preinc_ident	recolor=-1 # e.g. #embed __FILE__
+	" \t"		preinc_ws
+	"\""		preinc_local	recolor=-1
+	"<"		preinc_system	recolor=-1
+	"\n"		NULL		noeat return
+
+:preinc_local IncLocal string
+	*		preinc_local
+	"\""		preinc_trail
+	"\n"		NULL		noeat return
+
+:preinc_system IncSystem string
+	*		preinc_system
+	">"		preinc_trail
+	"\n"		NULL		noeat return
+
+:preinc_ident	Idle
+	*		preinc_trail	noeat
+	"\c"		preinc_ident
+
+:preinc_trail	Idle
+	*		NULL		noeat return
+	" \t"		preinc_trail
+	"\n"		NULL		noeat return
+.end
+
+.subr slash
+:slash Comment comment
+	*		NULL		noeat recolor=-2 return	# Not sure about this
+	"*"		comment		recolor=-2
+	"/"		line_comment	recolor=-2
+
+:comment Comment comment
+	*		comment
+	"BFHNTX"	comment		noeat call=comment_todo.comment_todo()
+	"*"		maybe_end_comment
+
+:maybe_end_comment Comment comment
+	*		comment
+	"/"		NULL		return
+	"*"		maybe_end_comment
+
+:line_comment Comment comment
+	*		line_comment
+	"BFHNTX"	line_comment	noeat call=comment_todo.comment_todo()
+	"\n"		NULL		noeat return
+.end

--- a/syntax/jsf.jsf
+++ b/syntax/jsf.jsf
@@ -77,7 +77,7 @@
 	"."		conditional_first	mark recolor=-1
 	"="		color_definition_first
 	":"		state_first
-	"*&%"		special_character	recolor=-1
+	"*&%~"		special_character	recolor=-1
 .endif
 	"\""		string			recolor=-1
 .ifdef STRINGS
@@ -359,6 +359,12 @@
 	"call"		call_color
 	"return"	option_color
 	"reset"		option_color
+	"sset"		option_flagword
+	"sclear"	option_flagword
+	"sflip"		option_flagword
+	"sifall"	option_flagword
+	"sifany"	option_flagword
+	"sifnone"	option_flagword
 	done
 .else
 	*		option_unknown		recolormark noeat strings
@@ -380,6 +386,12 @@
 	"call"		call_color
 	"return"	option_color
 	"reset"		option_color
+	"sset"		flagword_color
+	"sclear"	flagword_color_opt
+	"sflip"		flagword_color_opt
+	"sifall"	flagword_color_match
+	"sifany"	flagword_color_match
+	"sifnone"	flagword_color_match
 	done
 .endif
 	"\c"		option
@@ -560,12 +572,89 @@
 	*		call_parameter_bad
 	") \t#\n"	call_parameters_ws	noeat
 
+# Highlight the flag set/test options.
+:flagword_color Keyword
+	*		flagword_post		noeat call=.flagword_op()
+:flagword_color_opt Keyword
+	*		flagword_post		noeat call=.flagword_op(opt)
+:flagword_color_match Keyword
+	*		flagword_post		noeat call=.flagword_op(match)
+# Returned from .flagword_op.
+# If followed by whitespace or a comment, all is assumed to be well.
+:flagword_post Idle
+	*		option_bad		noeat #recolormark noeat
+	" \t"		options_ws		noeat
+	"#\n"		comment			noeat
+
+.subr flagword_op
+# sset must be followed by '=' or '@'.
+# sclear and sflip may be followed by '=' or '@'.
+# sif* must be followed by '=', '@' or '~'.
+:flagword_op Parameter #Idle
+.ifdef opt
+	*		NULL			noeat return
+.else
+	*		flagword_bad		noeat
+.endif
+	"="		flagword_word
+	"@"		flagword_list
+.ifdef match
+	"~"		flagword_match		mark hold
+.endif
+
+# Something unexpected. Return and let :option_bad take care of it.
+:flagword_bad Bad
+	*		NULL			recolormark noeat return
+
+# '=': Single number; decimal, hex or octal.
+:flagword_word Parameter
+	*		flagword_bad		noeat
+	"0"		flagword_oct_hex
+	"1-9"		flagword_decimal
+:flagword_decimal Parameter
+	*		NULL			noeat return
+	"0-9"		flagword_decimal
+:flagword_oct_hex Parameter
+	*		NULL			noeat return
+	"0-7"		flagword_oct
+	"xX"		flagword_hex
+:flagword_oct Parameter
+	*		NULL			noeat return
+	"0-7"		flagword_oct
+:flagword_hex Parameter
+	*		NULL			noeat return
+	"0-9A-Fa-f"	flagword_hex
+
+# '@': List of numbers, comma- or hyphen-separated.
+:flagword_list Parameter
+	*		flagword_bad		noeat
+	"0-9"		flagword_list_digits
+:flagword_list_digits Parameter
+	*		NULL			noeat return
+	"0-9"		flagword_list_digits
+	"-,"		flagword_list
+
+# '~': One of four keywords.
+:flagword_match Parameter
+	*		flagword_matching	noeat buffer
+:flagword_matching Parameter
+	*		flagword_bad		noeat onnomatch strings
+	"all"		flagword_matched
+	"any"		flagword_matched
+	"none"		flagword_matched
+	"other"		flagword_matched
+done
+	"\c"		flagword_matching
+
+:flagword_matched Parameter
+	*		NULL			noeat return
+.end
+
 # We saw something that is not a valid option name.  Continue to highlight it as
 # Bad until we see whitespace or a comment.
 :option_bad Bad
 	*		option_bad
 	" \t#\n"	options_ws		noeat
-
 
 ########
 # Done #

--- a/syntax/m4.jsf
+++ b/syntax/m4.jsf
@@ -21,7 +21,7 @@
 	*		idle
 	"["		idle recolor=-1 call=.m4(quote -brace)
 #	"["		idle recolor=-1 call=.quote()
-	"a-zA-Z_"	ident buffer mark
+	"a-zA-Z_"	ident_start	noeat mark
 .ifdef quote
 	"]"		idle return
 .endif
@@ -37,8 +37,14 @@
 	*		idle noeat return
 
 .ifdef quote
+:ident_start Constant string
+	*		ident	buffer
+
 :ident Constant string
 .else
+:ident_start Ident
+	*		ident	buffer
+
 :ident Ident
 .endif
 	*		maybe_macro noeat strings


### PR DESCRIPTION
This adds a set of commands for setting and testing flags and an extra match type intended for use with testing flag bits to the syntax colouring language. The flags word is, by default, saved and restored across subroutine calls.

The C colouring code is modified to make some simple use of this, tracking whether `#if 0` or `#if 1` have been seen in the current `#if` chain and making decisions about colouring based on that.

-- 

The main reason for its existence is that I couldn't see an easy way to handle the marking of definitely-`#if`'d-out blocks without storing state somewhere. (I _think_ that it's possible without this, but there'd be far too much duplication with all the maintenance headache which that brings.)

I wasn't sure how much I'd need (and I have no idea of how much will end up being used), so what got implemented is what seemed reasonable to provide enough flexibility to cover likely uses.