### PR TITLE
Fix parsing of compiler messages and handle absolute pathnames

### DIFF
--- a/joe/options.c
+++ b/joe/options.c
@@ -339,6 +339,7 @@ struct glopts {
 	{"menu_explorer",       GLO_OPT_BOOL, { &menu_explorer }, NULL, _("Menu explorer mode"), _("Simple completion mode"), _("Menu explorer mode"), 0, 0, 0 },
 	{"menu_above",          GLO_OPT_BOOL, { &menu_above }, NULL, _("Menu above prompt"), _("Menu below prompt"), _("Menu above/below mode"), 0, 0, 0 },
 	{"notagsmenu",          GLO_OPT_BOOL, { &notagsmenu }, NULL, _("Tags menu disabled"), _("Tags menu enabled"), _("Tags menu mode"), 0, 0, 0 },
+	{"parserr_homeonly",	GLO_OPT_BOOL, { &parserr_homeonly }, NULL, 0, 0, _("Error logs: home dir only"), 0, 0, 0 },
 	{"search_prompting",    GLO_OPT_BOOL, { &pico }, NULL, _("Search prompting on"), _("Search prompting off"), _("Search prompting mode"), 0, 0, 0 },
 	{"menu_jump",           GLO_OPT_BOOL, { &menu_jump }, NULL, _("Jump into menu is on"), _("Jump into menu is off"), _("Jump into menu mode"), 0, 0, 0 },
 	{"autoswap",            GLO_OPT_BOOL, { &autoswap }, NULL, _("Autoswap ^KB and ^KK"), _("Autoswap off "), _("Autoswap mode "), 0, 0, 0 },

--- a/joe/uerror.c
+++ b/joe/uerror.c
@@ -347,7 +347,7 @@ static int parseit(struct charmap *map,const char *s, off_t row,
 			/* We have an error */
 			err = (ERROR *) alitem(&errnodes, SIZEOF(ERROR));
 			err->file = name;
-			if (current_dir) {
+			if (current_dir && *name != '/') {
 				err->file = vsncpy(NULL, 0, sv(current_dir));
 				err->file = vsncpy(sv(err->file), sv(name));
 				err->file = canonical(err->file, CANFLAG_NORESTART);

--- a/joe/uerror.c
+++ b/joe/uerror.c
@@ -23,6 +23,8 @@ ERROR *errptr = &errors;	/* Current error row */
 
 B *errbuf = NULL;		/* Buffer with error messages */
 
+bool parserr_homeonly = true;	/* compiler errors: ignore file paths outside home directory */
+
 /* Function which allows stepping through all error buffers,
    for multi-file search and replace.  Give it a buffer.  It finds next
    buffer in error list.  Look at 'berror' for error information. */
@@ -336,6 +338,7 @@ static int parseit(struct charmap *map,const char *s, off_t row,
   void (*parseline)(struct charmap *map, const char *s, char **rtn_name, off_t *rtn_line), char *current_dir)
 {
 	char *name = NULL;
+	const char *home = parserr_homeonly ? getenv("HOME") : NULL;
 	off_t line = -1;
 	ERROR *err;
 
@@ -345,16 +348,20 @@ static int parseit(struct charmap *map,const char *s, off_t row,
 		if (line != -1) {
 			char *t;
 			/* We have an error */
-			err = (ERROR *) alitem(&errnodes, SIZEOF(ERROR));
-			err->file = name;
 			if (current_dir && *name != '/') {
-				err->file = vsncpy(NULL, 0, sv(current_dir));
-				err->file = vsncpy(sv(err->file), sv(name));
-				err->file = canonical(err->file, CANFLAG_NORESTART);
+				t = vsncpy(NULL, 0, sv(current_dir));
+				t = vsncpy(sv(t), sv(name));
+				t = canonical(t, CANFLAG_NORESTART);
 				vsrm(name);
 			} else {
-				err->file = name;
+				t = name;
 			}
+			if (home && zncmp(t, sz(home))) {
+				vsrm(name);
+				return 0;
+			}
+			err = (ERROR *) alitem(&errnodes, SIZEOF(ERROR));
+			err->file = t;
 			err->org = err->line = line;
 			err->src = row;
 			err->msg = vsncpy(NULL, 0, sc("\\i"));

--- a/joe/uerror.c
+++ b/joe/uerror.c
@@ -145,19 +145,73 @@ static int freeall(void)
 	return count;
 }
 
-/* Parse "make[1]: Entering directory '/home/..../foo'" message. */
+/* Parse "make[1]: Entering directory '/home/..../foo'" message.
+ * Allow for possible aliases, e.g. gmake, kmk_gmake.
+ */
 
-static void parsedir(const char *s, char **rtn_dir)
+static void parsedir(struct charmap *map, const char *s, char **rtn_dir)
 {
-	const char *u, *v;
-	u = zstr(s, "Entering directory `");
-	if (u) {
-		u += zlen("Entering directory `");
-		for (v = u; *v && *v != '\''; ++v);
-		if (*v == '\'') {
+	const char *u, *v, *vv; /* -funsigned-char */
+
+	u = zstr(s, "make[");
+	if (!u) return;
+	/* Possible aliases of make, so check the preceding text */
+	for (v = s; v < u; ++v) {
+		if ((*v & 0xDF) < 'A')
+			return;
+		if ((*v & 0xDF) > 'Z' && *v != '_')
+			return;
+	}
+
+	if (!zncmp(u, "make[", 5)) {
+		char quote[2][4] = {};
+
+		u = strchr(s, '[') + 1; /* < the [ which got matched above */
+		while (*u >= '0' && *u <= '9')
+			++u;
+		if (u == s + 5 || u[0] != ']' || u[1] != ':')
+			return;
+		/* looks like "make[1]" */
+
+		while (*u && !quote[0][0]) {
+			/* List of quotation marks:
+			 *   $ grep -h 'Entering directory' $(find make-dfsg-4.4.1 -name \*.po) -A1|sed -e '/^msgstr/! d; s/^[^"]*"//; s/"[^"]*$//; s@[[:alnum:][:space:] %:\\[\]]*@@g'|sort -u|sed -e ':t N; s/\n/ /; t t'
+			 *   "" '' `' «» “” ”” „“ „” 「」
+			 * Unicode code point numbers for each pair:
+			 * 0022 0022, 0027 0027, 0060 0027, 00AB 00BB, 201C 201D, 201D 201D, 201E 201C, 201E 201D, 300C 300D
+			 */
+			int c = fwrd_c(map, &u, NULL);
+			switch (c) {
+			/* ASCII */
+			case 0x0022: quote[0][0] = '"';  break;
+			case 0x0027: quote[0][0] = '\''; break;
+			case 0x0060: quote[0][0] = '\''; break;
+			/* Latin-(various), possibly encoded as UTF-8 */
+			case 0x00AB: if (map->type) utf8_encode(quote[0], 0xBB); else quote[0][0] = (char)0xBB; break;
+			/* UTF-8 */
+			case 0x201C: utf8_encode(quote[0], 0x201D); break;
+			case 0x201D: utf8_encode(quote[0], 0x201D); break;
+			case 0x201E: utf8_encode(quote[0], 0x201C);
+			             utf8_encode(quote[0], 0x201D); break;
+			case 0x300C: utf8_encode(quote[0], 0x300D); break;
+			}
+		}
+		if (!quote[0][0])
+			return; /* no recognised quotation mark found */
+
+		/* find the corresponding closing quotation mark (the last one!) */
+		v = u - 1;
+		do {
+			vv = zstr(v + 1, quote[0]);
+			if (!vv && quote[1][0]) vv = zstr(v + 1, quote[1]);
+			if (vv) v = vv;
+		} while (vv);
+
+		/* hopefully, we now have a non-empty string */
+		if (v > u + 1) {
 			char *t = *rtn_dir;
 			t = vstrunc(t, 0);
-			t = vsncpy(sv(t), u, v - u);
+			t = vsncpy(sv(t), (char *)u, v - u);
 			if (sLEN(t) && t[sLEN(t)-1] != '/')
 				t = vsadd(t, '/');
 			*rtn_dir = t;
@@ -340,7 +394,7 @@ static off_t parserr(B *b)
 			s = brvs(q, p->byte - q->byte);
 			if (s) {
 				kill_ansi(s);
-				parsedir(s, &curdir);
+				parsedir(q->b->o.charmap, s, &curdir);
 				nerrs += parseit(q->b->o.charmap, s, q->line, (q->b->parseone ? q->b->parseone : parseone), (curdir ? curdir : q->b->current_dir));
 				vsrm(s);
 			}
@@ -366,7 +420,7 @@ static off_t parserr(B *b)
 			s = brvs(q, p->byte - q->byte);
 			if (s) {
 				kill_ansi(s);
-				parsedir(s, &curdir);
+				parsedir(q->b->o.charmap, s, &curdir);
 				nerrs += parseit(q->b->o.charmap, s, q->line, (q->b->parseone ? q->b->parseone : parseone), (curdir ? curdir : q->b->current_dir));
 				vsrm(s);
 			}
@@ -550,7 +604,7 @@ int ujump(W *w, int k)
 		s = brvs(q, p->byte - q->byte);
 		if (s) {
 			kill_ansi(s);
-			parsedir(s, &curdir);
+			parsedir(bw->b->o.charmap, s, &curdir);
 			vsrm(s);
 		}
 		if (NO_MORE_DATA == pgetc(p))

--- a/joe/uerror.c
+++ b/joe/uerror.c
@@ -185,13 +185,13 @@ static void parsedir(struct charmap *map, const char *s, char **rtn_dir)
 			/* ASCII */
 			case 0x0022: quote[0][0] = '"';  break;
 			case 0x0027: quote[0][0] = '\''; break;
-			case 0x0060: quote[0][0] = '\''; break;
+			case 0x0060: quote[1][0] = '`'; quote[0][0] = '\''; break;
 			/* Latin-(various), possibly encoded as UTF-8 */
 			case 0x00AB: if (map->type) utf8_encode(quote[0], 0xBB); else quote[0][0] = (char)0xBB; break;
 			/* UTF-8 */
 			case 0x201C: utf8_encode(quote[0], 0x201D); break;
 			case 0x201D: utf8_encode(quote[0], 0x201D); break;
-			case 0x201E: utf8_encode(quote[0], 0x201C);
+			case 0x201E: utf8_encode(quote[1], 0x201C);
 			             utf8_encode(quote[0], 0x201D); break;
 			case 0x300C: utf8_encode(quote[0], 0x300D); break;
 			}

--- a/joe/uerror.h
+++ b/joe/uerror.h
@@ -6,6 +6,8 @@
  *	This file is part of JOE (Joe's Own Editor)
  */
 
+extern bool parserr_homeonly;
+
 int unxterr(W *w, int k);
 int uprverr(W *w, int k);
 int parserrb(B *b);

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -142,6 +142,10 @@
 
  -notagsmenu	Disable tags file search menu
 
+-parserr_homeonly
+		In compiler error logs, ignore files (system header files
+		etc.) which are outside the user's home directory.
+
  -icase         Search is case insensitive by default.
 
  -wrap          Search wraps


### PR DESCRIPTION
Looking for `Entering directory \x60` doesn't work because `make` uses `'`, not <code>`</code>. But that's all localised: both the words and the quotation marks used vary.

Also, it's possible that some of the names in the compiler output are absolute pathnames; no checking was being done for that, and the current directory name was being prepended regardless when trying to open one of them.

(Ugh. Stupid Gitbug Markdown handling of backticks.)