### PR TITLE
Fix several problems in signal handler autoconf check

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -59,9 +59,16 @@ AC_DEFUN([joe_REINSTALL_SIGHANDLERS],
 #include <signal.h>
 #endif
 
+#ifndef RETSIGTYPE
+typedef void RETSIGTYPE;
+#endif
+
 #ifndef HAVE_SIGHANDLER_T
 typedef RETSIGTYPE (*sighandler_t)(int);
 #endif
+
+void set_signal(int signum, sighandler_t handler);
+RETSIGTYPE sigint(int s);
 
 int nsigint;
 
@@ -86,6 +93,7 @@ void set_signal(int signum, sighandler_t handler) {
 }
 
 RETSIGTYPE sigint(int s) {
+	(void)s;
 	nsigint++;
 }
 


### PR DESCRIPTION
The autoconf check for signal handler behaviour has several problems which lead to extremely confusing error messages and incorrect autoconf behaviour:

- RETSIGTYPE is no longer defined because it has long been deprecated; since C89 signal handlers always return void. This causes both a build error and an implicit redefinition to int, leading to more problems.

- the test is missing two prototypes for its own functions, which can lead to unexpected failures completely unrelated to signal handling.

- very strict compiler settings lead to a warning about an unused function argument in the signal handler. Not critical, but easy to prevent in a portable manner by sinking the signal value into a void expression.

With these changes the check compiles cleanly and correctly indicates the expected behaviour to autoconf.