### PR TITLE
Allow notmod in PW

### DIFF
--- a/joe/cmd.c
+++ b/joe/cmd.c
@@ -139,7 +139,7 @@ const CMD cmds[] = {
 	{"nextw", TYPETW + TYPEPW + TYPEMENU + TYPEQW, unextw, NULL, 1, "prevw"},
 	{"nextword", TYPETW + TYPEPW + EFIXXCOL, u_goto_next, NULL, 1, "prevword"},
 	{"nmark", TYPETW + TYPEPW, unmark, NULL, 0, NULL},
-	{"notmod", TYPETW, unotmod, NULL, 0, NULL},
+	{"notmod", TYPETW + TYPEPW, unotmod, NULL, 0, NULL},
 	{"nxterr", TYPETW, unxterr, NULL, 1, "prverr"},
 	{"open", TYPETW + TYPEPW + EFIXXCOL + EMOD, uopen, NULL, 1, "deleol"},
 	{"parserr", TYPETW, uparserr, NULL, 0, NULL},


### PR DESCRIPTION
Allows the "notmod" command to be used in a prompt window. This is useful because JOE does not append to the prompt history if it thinks the prompt buffer was not modified. This means it can be used in a macro to avoid clobbering the history with stuff you don't care about.