### PR TITLE
Syntax fixes

### DIFF
--- a/syntax/debian.jsf
+++ b/syntax/debian.jsf
@@ -204,7 +204,7 @@ done
 
 :name String # continuation
 	*		comma		noeat call=.space()
-	"-\c"		name
+	"-.\c"		name
 	"\s"		comma		noeat call=.space()
 	"\n"		comma_reset
 

--- a/syntax/rust.jsf
+++ b/syntax/rust.jsf
@@ -38,7 +38,7 @@
 	"\""		string		recolor=-1
 	"'"		char		recolor=-1
 	"/"		slash		recolor=-1
-	"\i"		ident		buffer
+	"\i"		ident		buffer recolor=-1
 
 :slash Idle
 	*		idle		noeat


### PR DESCRIPTION
rust: off-by-one
debian: missing character ('.' in package names)

(4.7, main)

(Merge whenever, but I'll add more here as I see & fix them.)