### PR TITLE
Fix tags file security vulnerability

### DIFF
--- a/joe/b.c
+++ b/joe/b.c
@@ -2513,6 +2513,19 @@ B *bread(int fi, off_t max, int binary)
 	return b;
 }
 
+/* Return true if filename will be interpreted as something other than a filename by bload()
+   It would be better to have a flag on bload, but more plumbing required */
+
+int hack_check(const char *name)
+{
+	if (name[0] == '!')
+		return 1;
+	else if (name[0] == '>' && name[1] == '>')
+		return 1;
+	else
+		return 0;
+}
+
 /* Parse file name.
  *
  * Removes ',xxx,yyy' from end of name and puts their value into skip and amnt

--- a/joe/b.h
+++ b/joe/b.h
@@ -351,3 +351,6 @@ int ansi_code(char *s);
 char *ansi_string(int code);
 
 extern bool guess_utf16;
+
+/* Return true if filename will be interpreted as something other than a filename */
+int hack_check(const char *name);

--- a/joe/main.c
+++ b/joe/main.c
@@ -754,7 +754,7 @@ int main(int argc, char **real_argv, const char * const *envv)
 			cstart ((BW *)maint->curwin->object, NULL, NULL, NULL, NULL, 0, 1, NULL, SHELL_TYPE_RAW);
 			/* Close stdin, so that if user kills the copying the program feeding stdin sees a SIGPIPE */
 			/* It won't if there are any extra file descriptors open */
-			fclose(stdin);
+			//fclose(stdin);
 		}
 	}
 

--- a/joe/uerror.c
+++ b/joe/uerror.c
@@ -471,6 +471,9 @@ int ugparse(W *w, int k)
 static int jump_to_file_line(BW *bw,char *file,off_t line,char *msg)
 {
 	int omid;
+	/* Do not allow shell command! */
+	if (hack_check(file))
+		return -1;
 	if (!bw->b->name || zcmp(file, bw->b->name)) {
 		if (doswitch(bw->parent, vsdup(file), NULL, NULL))
 			return -1;

--- a/joe/utag.c
+++ b/joe/utag.c
@@ -222,7 +222,7 @@ static int dotag(W *w, char *s, void *obj, int *notify)
 				++x;
 			}
 			for (y = x; buf[y] && buf[y] != ' ' && buf[y] != '\t' && buf[y] != '\n'; ++y) ;
-			if (x != y) {
+			if (x != y && !hack_check(buf)) { /* Do not allow shell commands in tags file! */
 				char *file = 0;
 				c = buf[y];
 				buf[y] = 0;

--- a/joe/utag.c
+++ b/joe/utag.c
@@ -222,7 +222,7 @@ static int dotag(W *w, char *s, void *obj, int *notify)
 				++x;
 			}
 			for (y = x; buf[y] && buf[y] != ' ' && buf[y] != '\t' && buf[y] != '\n'; ++y) ;
-			if (x != y && !hack_check(buf)) { /* Do not allow shell commands in tags file! */
+			if (x != y && !hack_check(buf + x)) { /* Do not allow shell commands in tags file! */
 				char *file = 0;
 				c = buf[y];
 				buf[y] = 0;


### PR DESCRIPTION
Suppress shell command interpretation in tags file, because:


JOE's tag-search feature (default `^K ;`) parses a `tags` file and feeds the `FILE` field of a matched entry directly to `bfind()` / `bload()`.  `bload()` honors the long-standing convention that filenames beginning with `!` are executed via `/bin/sh -c` (intended for interactive prompts).  No validation is performed on the `FILE` field parsed from `tags`, so a

malicious entry of the form:

    intmain<TAB>!/path/to/payload<TAB>1

results in `/bin/sh -c /path/to/payload` the moment the victim performs a matching tag search. With `-notagsmenu` (or on a single-match query) there is no confirmation prompt.

Affected
--------

- JOE 4.7 (current `default` branch; reviewed against

  https://github.com/joe-editor/joe)

- Expected to affect all earlier releases carrying the same `utag.c`

  parser + `bload()` shell-escape convention.

- Default binaries: `joe`, `jmacs`, `jpico`, `jstar`. `rjoe` comments

  out the `tag` binding in `rjoerc.in` and is not exposed by default.

Severity

--------

CVSS 3.1 base score 7.8 (High) —

AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H

CWE-94 (Code Injection), CWE-78 (OS Command Injection).

Details
-------

Full write-up, reproduction steps, observed `id` output from the PoC, and a minimal-diff suggested fix are included in the attached advisory:

  JOE-2026-0001-ADVISORY.md
  01-rce-tags-file.md
  poc-01-tags-rce/     (tags, pwn.sh, prog.c, poc2.exp)

 
The core of the suggested fix is to reject `FILE` fields beginning with `!` or `>>` at parse time in `utag.c:dotag()`, before they can reach `bload()`. A more defensive option is to gate the `n[0] == '!'` path in `bload()` itself behind a "came from interactive prompt" flag.
