### PR TITLE
Fix selection bugs, make ^Z / ^X consistent

### DIFF
--- a/joe/uedit.c
+++ b/joe/uedit.c
@@ -193,6 +193,8 @@ static int p_goto_prev(P *ptr)
 	} else if (joe_isspace(map,c) || joe_ispunct(map,c)) {
 		while ((c=prgetc(p)), (joe_isspace(map,c) || joe_ispunct(map,c)))
 			/* Do nothing */;
+		if (c != NO_MORE_DATA)
+			pgetc(p);
 		while(joe_isalnum_(map,(c=prgetc(p))))
 			/* Do nothing */;
 		if (c != NO_MORE_DATA)

--- a/rc/jicerc.ru.in
+++ b/rc/jicerc.ru.in
@@ -943,20 +943,20 @@ if,"markv",then,blkdel,nmark,else,delw,endif		^[ [ 3 ^
 
  New Shift-
 
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ a		rxvt
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ b
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ c
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ d
-uparw,dnarw,begin_marking,pgup,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
-dnarw,uparw,begin_marking,pgdn,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ a		rxvt
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ b
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ c
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ d
+uparw,dnarw,begin_marking,pgup!,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
+dnarw,uparw,begin_marking,pgdn!,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 ; 2 ~	Ctrl-Del Delete block or line
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 $
  dellin		^[ [ 3 ; 2 ~	Shift-Del
@@ -975,21 +975,21 @@ ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Le
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 5 A        Old Gnome-terminal
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ O a		Rxvt
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 5 A        Old Gnome-terminal
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ O a		Rxvt
 
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 5 B        Mark down
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ O b
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 5 B        Mark down
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ O b
 
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 5 C
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ O c
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 5 C
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ O c
 
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 5 D
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ O d
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 5 D
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ O d
 
 paste			^[ [ 2 0 2 ~		Base64 paste (obsolete) ???
 brpaste			^[ [ 2 0 0 ~		Bracketed paste

--- a/rc/jicerc.ru.in
+++ b/rc/jicerc.ru.in
@@ -967,11 +967,11 @@ yank		^[ [ 2 $
  Shift-Ctrl-
 
  upslide		^[ [ 1 ; 6 A	Shift-Ctrl-Up
-uparw,dnarw,begin_marking,bop,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
+uparw,dnarw,begin_marking,bop!,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
  dnslide		^[ [ 1 ; 6 B	Shift-Ctrl-Down
-dnarw,uparw,begin_marking,eop,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
-rtarw,ltarw,begin_marking,nextword,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
-ltarw,rtarw,begin_marking,prevword,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
+dnarw,uparw,begin_marking,eop!,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
+rtarw,ltarw,begin_marking,nextword!,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
+ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -1002,11 +1002,11 @@ yank		^[ [ 2 $
  Shift-Ctrl-
 
  upslide		^[ [ 1 ; 6 A	Shift-Ctrl-Up
-uparw,dnarw,begin_marking,bop,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
+uparw,dnarw,begin_marking,bop!,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
  dnslide		^[ [ 1 ; 6 B	Shift-Ctrl-Down
-dnarw,uparw,begin_marking,eop,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
-rtarw,ltarw,begin_marking,nextword,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
-ltarw,rtarw,begin_marking,prevword,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
+dnarw,uparw,begin_marking,eop!,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
+rtarw,ltarw,begin_marking,nextword!,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
+ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 

--- a/rc/joerc.in
+++ b/rc/joerc.in
@@ -978,20 +978,20 @@ if,"markv",then,blkdel,nmark,else,delw,endif		^[ [ 3 ^
 
  New Shift-
 
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ a		rxvt
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ b
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ c
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ d
-uparw,dnarw,begin_marking,pgup,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
-dnarw,uparw,begin_marking,pgdn,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ a		rxvt
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ b
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ c
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ d
+uparw,dnarw,begin_marking,pgup!,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
+dnarw,uparw,begin_marking,pgdn!,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 ; 2 ~	Ctrl-Del Delete block or line
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 $
  dellin		^[ [ 3 ; 2 ~	Shift-Del
@@ -1010,21 +1010,21 @@ ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Le
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 5 A        Old Gnome-terminal
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ O a		Rxvt
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 5 A        Old Gnome-terminal
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ O a		Rxvt
 
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 5 B        Mark down
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ O b
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 5 B        Mark down
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ O b
 
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 5 C
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ O c
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 5 C
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ O c
 
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 5 D
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ O d
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 5 D
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ O d
 
  Extra functions not really part of JOE user interface:
 

--- a/rc/joerc.zh_TW.in
+++ b/rc/joerc.zh_TW.in
@@ -924,20 +924,20 @@ if,"markv",then,blkdel,nmark,else,delw,endif		^[ [ 3 ^
 
  New Shift-
 
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ a		rxvt
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ b
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ c
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ d
-uparw,dnarw,begin_marking,pgup,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
-dnarw,uparw,begin_marking,pgdn,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ a		rxvt
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ b
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ c
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ d
+uparw,dnarw,begin_marking,pgup!,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
+dnarw,uparw,begin_marking,pgdn!,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 ; 2 ~	Ctrl-Del Delete block or line
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 $
  dellin		^[ [ 3 ; 2 ~	Shift-Del
@@ -956,21 +956,21 @@ ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Le
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 5 A        Old Gnome-terminal
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ O a		Rxvt
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 5 A        Old Gnome-terminal
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ O a		Rxvt
 
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 5 B        Mark down
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ O b
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 5 B        Mark down
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ O b
 
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 5 C
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ O c
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 5 C
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ O c
 
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 5 D
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ O d
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 5 D
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ O d
 
  Extra functions not really part of JOE user interface:
 

--- a/rc/joerc.zh_TW.in
+++ b/rc/joerc.zh_TW.in
@@ -948,11 +948,11 @@ yank		^[ [ 2 $
  Shift-Ctrl-
 
  upslide		^[ [ 1 ; 6 A	Shift-Ctrl-Up
-uparw,dnarw,begin_marking,bop,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
+uparw,dnarw,begin_marking,bop!,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
  dnslide		^[ [ 1 ; 6 B	Shift-Ctrl-Down
-dnarw,uparw,begin_marking,eop,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
-rtarw,ltarw,begin_marking,nextword,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
-ltarw,rtarw,begin_marking,prevword,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
+dnarw,uparw,begin_marking,eop!,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
+rtarw,ltarw,begin_marking,nextword!,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
+ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 

--- a/rc/jstarrc.in
+++ b/rc/jstarrc.in
@@ -864,11 +864,11 @@ yank		^[ [ 2 $
  Shift-Ctrl-
 
  upslide		^[ [ 1 ; 6 A	Shift-Ctrl-Up
-uparw,dnarw,begin_marking,bop,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
+uparw,dnarw,begin_marking,bop!,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
  dnslide		^[ [ 1 ; 6 B	Shift-Ctrl-Down
-dnarw,uparw,begin_marking,eop,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
-rtarw,ltarw,begin_marking,nextword,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
-ltarw,rtarw,begin_marking,prevword,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
+dnarw,uparw,begin_marking,eop!,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
+rtarw,ltarw,begin_marking,nextword!,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
+ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 

--- a/rc/jstarrc.in
+++ b/rc/jstarrc.in
@@ -840,20 +840,20 @@ if,"markv",then,blkdel,nmark,else,delw,endif		^[ [ 3 ^
 
  New Shift-
 
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ a		rxvt
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ b
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ c
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ d
-uparw,dnarw,begin_marking,pgup,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
-dnarw,uparw,begin_marking,pgdn,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ a		rxvt
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ b
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ c
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ d
+uparw,dnarw,begin_marking,pgup!,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
+dnarw,uparw,begin_marking,pgdn!,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 ; 2 ~	Ctrl-Del Delete block or line
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 $
  dellin		^[ [ 3 ; 2 ~	Shift-Del
@@ -872,21 +872,21 @@ ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Le
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 5 A        Old Gnome-terminal
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ O a		Rxvt
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 5 A        Old Gnome-terminal
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ O a		Rxvt
 
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 5 B        Mark down
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ O b
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 5 B        Mark down
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ O b
 
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 5 C
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ O c
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 5 C
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ O c
 
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 5 D
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ O d
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 5 D
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ O d
 
 
 paste			^[ ] 5 2 ;		Base64 paste (obsolete)

--- a/rc/rjoerc.in
+++ b/rc/rjoerc.in
@@ -807,20 +807,20 @@ if,"markv",then,blkdel,nmark,else,delw,endif		^[ [ 3 ^
 
  New Shift-
 
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
-uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ a		rxvt
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
-dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ b
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
-rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ c
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
-ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ d
-uparw,dnarw,begin_marking,pgup,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
-dnarw,uparw,begin_marking,pgdn,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
-ltarw,rtarw,begin_marking,bol,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
-rtarw,ltarw,begin_marking,eol,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 2 A    Shift-Up	Mark up line
+uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ a		rxvt
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 2 B    Shift-Down	Mark down line
+dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ b
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 2 C    Shift-Right	Mark right
+rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ c
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 2 D    Shift-Left	Mark left
+ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ d
+uparw,dnarw,begin_marking,pgup!,toggle_marking	^[ [ 5 ; 2 ~    Shift-PgUp	Mark up page [Usually scrolls back]
+dnarw,uparw,begin_marking,pgdn!,toggle_marking	^[ [ 6 ; 2 ~    Shift-PgDn	Mark down page [Usually scrolls forward]
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 1 ; 2 H    Shift-Home	Mark to bol
+ltarw,rtarw,begin_marking,bol!,toggle_marking	^[ [ 7 $ 	Shift-Home	Mark to bol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 1 ; 2 F    Shift-End	Mark to eol
+rtarw,ltarw,begin_marking,eol!,toggle_marking	^[ [ 8 $ 	Shift-End	Mark to eol
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 ; 2 ~	Ctrl-Del Delete block or line
 if,"markv",then,blkdel,nmark,else,dellin,endif		^[ [ 3 $
  dellin		^[ [ 3 ; 2 ~	Shift-Del
@@ -839,21 +839,21 @@ ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Le
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ [ 5 A        Old Gnome-terminal
- uparw,dnarw,begin_marking,uparw,toggle_marking	^[ O a		Rxvt
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 1 ; 5 A    Ctrl-Up Mark up line
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ [ 5 A        Old Gnome-terminal
+ uparw,dnarw,begin_marking,uparw!,toggle_marking	^[ O a		Rxvt
 
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ [ 5 B        Mark down
- dnarw,uparw,begin_marking,dnarw,toggle_marking	^[ O b
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 1 ; 5 B    Ctrl-Down Mark down line
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ [ 5 B        Mark down
+ dnarw,uparw,begin_marking,dnarw!,toggle_marking	^[ O b
 
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ [ 5 C
- rtarw,ltarw,begin_marking,rtarw,toggle_marking	^[ O c
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 1 ; 5 C    Ctrl-Right Mark right
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ [ 5 C
+ rtarw,ltarw,begin_marking,rtarw!,toggle_marking	^[ O c
 
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ [ 5 D
- ltarw,rtarw,begin_marking,ltarw,toggle_marking	^[ O d
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 1 ; 5 D    Ctrl-Left Mark left
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ [ 5 D
+ ltarw,rtarw,begin_marking,ltarw!,toggle_marking	^[ O d
 
 
 paste			^[ ] 5 2 ;		Base64 paste (obsolete)

--- a/rc/rjoerc.in
+++ b/rc/rjoerc.in
@@ -831,11 +831,11 @@ yank		^[ [ 2 $
  Shift-Ctrl-
 
  upslide		^[ [ 1 ; 6 A	Shift-Ctrl-Up
-uparw,dnarw,begin_marking,bop,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
+uparw,dnarw,begin_marking,bop!,toggle_marking	^[ [ 1 ; 6 A    Mark up paragraph
  dnslide		^[ [ 1 ; 6 B	Shift-Ctrl-Down
-dnarw,uparw,begin_marking,eop,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
-rtarw,ltarw,begin_marking,nextword,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
-ltarw,rtarw,begin_marking,prevword,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
+dnarw,uparw,begin_marking,eop!,toggle_marking	^[ [ 1 ; 6 B    Mark down paragraph
+rtarw,ltarw,begin_marking,nextword!,toggle_marking	^[ [ 1 ; 6 C    Shift-Ctrl-Right Mark right word
+ltarw,rtarw,begin_marking,prevword!,toggle_marking	^[ [ 1 ; 6 D    Shift-Ctrl-Left Mark left word
 
  Uncomment these if you want JOE to work the old way (Ctrl-cursor marks)
 


### PR DESCRIPTION
sf #427 and sf #428

^Z skips more than ^X due to code not matching.  JOE only skips whitespace/punctuation and alphanumeric, otherwise it moves by one character.  VS code skips over things like '==='.

nextword/prevword would return an error (non-zero return value) if they did not skip for jmacs mode to ring the bell.  But this caused an early abort of the Ctrl-Select macro, which was messing up the selection.  The fix is to ignore these errors.
